### PR TITLE
Fix all compiler warnings across workspace

### DIFF
--- a/crates/aivcs-core/src/main.rs
+++ b/crates/aivcs-core/src/main.rs
@@ -24,7 +24,7 @@ use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
 mod parallel;
-use parallel::{fork_agent_parallel, ParallelConfig, ParallelManager};
+use parallel::fork_agent_parallel;
 
 #[derive(Parser)]
 #[command(name = "aivcs")]

--- a/crates/aivcs-core/src/parallel.rs
+++ b/crates/aivcs-core/src/parallel.rs
@@ -21,6 +21,7 @@ use tracing::{debug, info, warn};
 #[derive(Debug, Clone)]
 pub struct ForkResult {
     /// Parent commit that was forked from
+    #[allow(dead_code)]
     pub parent_commit: String,
     /// Branch names created
     pub branches: Vec<String>,
@@ -49,8 +50,10 @@ pub struct ParallelConfig {
     /// Minimum score threshold (branches below this get pruned)
     pub score_threshold: f32,
     /// Maximum concurrent branches
+    #[allow(dead_code)]
     pub max_branches: usize,
     /// Auto-prune low performers
+    #[allow(dead_code)]
     pub auto_prune: bool,
 }
 
@@ -151,6 +154,7 @@ pub async fn fork_agent_parallel(
 
 /// Parallel branch manager for tracking and pruning branches
 pub struct ParallelManager {
+    #[allow(dead_code)]
     handle: Arc<SurrealHandle>,
     config: ParallelConfig,
     branch_status: Arc<Mutex<Vec<BranchStatus>>>,

--- a/crates/nix-env-manager/src/attic.rs
+++ b/crates/nix-env-manager/src/attic.rs
@@ -188,7 +188,7 @@ impl AtticClient {
     }
 
     /// Push using Attic CLI
-    async fn push_cli(&self, hash: &NixHash, store_path: &Path) -> Result<()> {
+    async fn push_cli(&self, _hash: &NixHash, store_path: &Path) -> Result<()> {
         // Check if attic CLI is available
         let attic_available = Command::new("attic")
             .arg("--version")

--- a/crates/nix-env-manager/src/flake.rs
+++ b/crates/nix-env-manager/src/flake.rs
@@ -263,6 +263,7 @@ pub fn get_flake_metadata(flake_path: &Path) -> Result<FlakeMetadata> {
 }
 
 /// Lock flake inputs (equivalent to `nix flake lock`)
+#[allow(dead_code)]
 pub fn lock_flake(flake_path: &Path) -> Result<()> {
     let output = Command::new("nix")
         .args(["flake", "lock"])
@@ -278,6 +279,7 @@ pub fn lock_flake(flake_path: &Path) -> Result<()> {
 }
 
 /// Update flake inputs (equivalent to `nix flake update`)
+#[allow(dead_code)]
 pub fn update_flake(flake_path: &Path) -> Result<NixHash> {
     let output = Command::new("nix")
         .args(["flake", "update"])
@@ -296,7 +298,6 @@ pub fn update_flake(flake_path: &Path) -> Result<NixHash> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
     use tempfile::tempdir;
 
     #[test]

--- a/crates/nix-env-manager/src/logic.rs
+++ b/crates/nix-env-manager/src/logic.rs
@@ -135,6 +135,7 @@ fn normalize_source(content: &[u8]) -> Vec<u8> {
 }
 
 /// Generate hash for a Cargo.toml file (dependencies affect logic)
+#[allow(dead_code)]
 pub fn generate_cargo_hash(cargo_path: &Path) -> Result<String> {
     let content = std::fs::read(cargo_path)?;
 
@@ -145,6 +146,7 @@ pub fn generate_cargo_hash(cargo_path: &Path) -> Result<String> {
 }
 
 /// Generate a combined hash of source + dependencies
+#[allow(dead_code)]
 pub fn generate_full_logic_hash(project_path: &Path) -> Result<String> {
     let mut hasher = Sha256::new();
 


### PR DESCRIPTION
## Summary

Fixes all 9 compiler warnings across the workspace (nix-env-manager: 5, aivcs-core: 4).

### nix-env-manager (5 warnings)
- Prefix unused `hash` parameter with underscore in `attic.rs` `push_cli`
- Remove unused `std::io::Write` import from `flake.rs` test module
- Add `#[allow(dead_code)]` to public API functions not yet called from main: `lock_flake`, `update_flake`, `generate_cargo_hash`, `generate_full_logic_hash`

### aivcs-core (4 warnings)
- Remove unused `ParallelConfig` and `ParallelManager` imports from `main.rs`
- Add `#[allow(dead_code)]` to public struct fields reserved for future use: `ForkResult.parent_commit`, `ParallelConfig.max_branches`/`auto_prune`, `ParallelManager.handle`

## Test plan

- [x] `cargo test --all` passes (46 tests, 0 warnings)

Generated with [Claude Code](https://claude.com/claude-code)
