### PR TITLE
Fix fork command persistence and enable local DB config

### DIFF
--- a/crates/aivcs-core/src/main.rs
+++ b/crates/aivcs-core/src/main.rs
@@ -217,7 +217,7 @@ async fn main() -> Result<()> {
         .context("Failed to set tracing subscriber")?;
 
     // Initialize database connection
-    let handle = SurrealHandle::setup_db().await
+    let handle = SurrealHandle::setup_from_env().await
         .context("Failed to connect to AIVCS database")?;
 
     match cli.command {
@@ -669,20 +669,11 @@ async fn cmd_fork(
 
     println!("Forking {} branches from {} with prefix '{}'", count, &parent_commit[..8.min(parent_commit.len())], prefix);
 
-    let handle_arc = Arc::new(SurrealHandle::setup_db().await?);
-
-    // Copy parent snapshot to new handle
-    let parent_snapshot = handle.load_snapshot(&parent_commit).await?;
-    let parent_id = CommitId::from_state(parent_commit.as_bytes());
-    handle_arc.save_snapshot(&parent_id, parent_snapshot.state.clone()).await?;
-
-    // Create parent commit in new handle
-    let parent_record = CommitRecord::new(parent_id.clone(), None, "Fork parent", "fork");
-    handle_arc.save_commit(&parent_record).await?;
+    let handle_arc = Arc::new(handle.clone());
 
     let result = fork_agent_parallel(
         handle_arc,
-        &parent_id.hash,
+        &parent_commit,
         count,
         prefix,
     ).await?;
@@ -781,5 +772,37 @@ mod tests {
         // Verify we can get the branch head
         let head = handle.get_branch_head("main").await.unwrap();
         assert!(!head.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_cmd_fork_creates_branches_in_same_db() {
+        let handle = SurrealHandle::setup_db().await.unwrap();
+
+        // Initialize repo
+        cmd_init(&handle, &PathBuf::from(".")).await.unwrap();
+
+        // Create a snapshot to fork from
+        let temp_dir = tempfile::tempdir().unwrap();
+        let state_path = temp_dir.path().join("state.json");
+        std::fs::write(&state_path, r#"{"step": 1, "value": "test"}"#).unwrap();
+        cmd_snapshot(&handle, &state_path, "Base", "agent", "main").await.unwrap();
+
+        // Run fork command
+        let result = cmd_fork(
+            &handle,
+            "main",
+            2,
+            "test-fork",
+        ).await;
+
+        assert!(result.is_ok(), "Fork failed: {:?}", result.err());
+
+        // Verify branches exist in the original handle
+        let branches = handle.list_branches().await.unwrap();
+        let fork_branches: Vec<_> = branches.iter()
+            .filter(|b| b.name.starts_with("test-fork"))
+            .collect();
+
+        assert_eq!(fork_branches.len(), 2, "Should have created 2 branches in the same DB");
     }
 }

--- a/crates/oxidized-state/src/handle.rs
+++ b/crates/oxidized-state/src/handle.rs
@@ -115,6 +115,7 @@ impl CloudConfig {
 }
 
 /// SurrealDB connection handle for AIVCS
+#[derive(Clone)]
 pub struct SurrealHandle {
     db: Surreal<Any>,
 }
@@ -200,19 +201,33 @@ impl SurrealHandle {
     /// Connect using environment variables
     ///
     /// If SURREALDB_ENDPOINT is set, connects to cloud.
+    /// If SURREALDB_URL is set, connects to that URL.
     /// Otherwise, falls back to in-memory.
     #[instrument(skip_all)]
     pub async fn setup_from_env() -> Result<Self> {
-        match CloudConfig::from_env() {
-            Ok(config) => {
-                info!("Cloud config found, connecting to SurrealDB Cloud");
-                Self::setup_cloud(config).await
-            }
-            Err(_) => {
-                info!("No cloud config found, using in-memory database");
-                Self::setup_db().await
-            }
+        if let Ok(config) = CloudConfig::from_env() {
+            info!("Cloud config found, connecting to SurrealDB Cloud");
+            return Self::setup_cloud(config).await;
         }
+
+        if let Ok(url) = std::env::var("SURREALDB_URL") {
+            info!("SURREALDB_URL found, connecting to {}", url);
+            let db = surrealdb::engine::any::connect(&url)
+                .await
+                .map_err(|e| StateError::Connection(e.to_string()))?;
+
+            db.use_ns("aivcs")
+                .use_db("main")
+                .await
+                .map_err(|e| StateError::Connection(e.to_string()))?;
+
+            let handle = SurrealHandle { db };
+            handle.init_schema().await?;
+            return Ok(handle);
+        }
+
+        info!("No cloud config found, using in-memory database");
+        Self::setup_db().await
     }
 
     /// Initialize the database schema


### PR DESCRIPTION
This PR fixes a critical bug where the `fork` command would create branches in a temporary in-memory database that was discarded immediately, resulting in data loss. It also enables the CLI to connect to a local persistent SurrealDB instance via `SURREALDB_URL` environment variable.

Changes:
- `crates/oxidized-state/src/handle.rs`: Derived `Clone` for `SurrealHandle` and updated `setup_from_env` to support `SURREALDB_URL`.
- `crates/aivcs-core/src/main.rs`: Updated `main()` to use `setup_from_env()` and fixed `cmd_fork` to use the shared handle. Added a regression test.

---
*PR created automatically by Jules for task [17076164643865857141](https://jules.google.com/task/17076164643865857141) started by @stevei101*