### PR TITLE
feat(domain): add canonical domain models (AgentSpec, Run, EvalSuite, Release)

### DIFF
--- a/crates/aivcs-core/src/domain/agent_spec.rs
+++ b/crates/aivcs-core/src/domain/agent_spec.rs
@@ -1,0 +1,249 @@
+//! Agent specification and digest computation.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use super::error::{AivcsError, Result};
+
+/// Canonical specification for an agent, including all digest components.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentSpec {
+    /// Unique identifier for this spec version.
+    pub spec_id: Uuid,
+
+    /// SHA256 hex digest of canonical JSON representation.
+    pub spec_digest: String,
+
+    /// Git commit SHA where this spec was defined.
+    pub git_sha: String,
+
+    /// SHA256 hex of graph definition bytes.
+    pub graph_digest: String,
+
+    /// SHA256 hex of prompts definition.
+    pub prompts_digest: String,
+
+    /// SHA256 hex of tools definition.
+    pub tools_digest: String,
+
+    /// SHA256 hex of configuration.
+    pub config_digest: String,
+
+    /// When this spec was created.
+    pub created_at: DateTime<Utc>,
+
+    /// Additional metadata.
+    pub metadata: serde_json::Value,
+}
+
+/// Input fields for computing agent spec digest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentSpecFields {
+    pub git_sha: String,
+    pub graph_digest: String,
+    pub prompts_digest: String,
+    pub tools_digest: String,
+    pub config_digest: String,
+}
+
+impl AgentSpec {
+    /// Create a new agent spec with computed digest.
+    pub fn new(
+        git_sha: String,
+        graph_digest: String,
+        prompts_digest: String,
+        tools_digest: String,
+        config_digest: String,
+    ) -> Result<Self> {
+        if git_sha.is_empty() {
+            return Err(AivcsError::InvalidAgentSpec(
+                "git_sha cannot be empty".to_string(),
+            ));
+        }
+
+        let fields = AgentSpecFields {
+            git_sha: git_sha.clone(),
+            graph_digest: graph_digest.clone(),
+            prompts_digest: prompts_digest.clone(),
+            tools_digest: tools_digest.clone(),
+            config_digest: config_digest.clone(),
+        };
+
+        let spec_digest = Self::compute_digest(&fields)?;
+
+        Ok(Self {
+            spec_id: Uuid::new_v4(),
+            spec_digest,
+            git_sha,
+            graph_digest,
+            prompts_digest,
+            tools_digest,
+            config_digest,
+            created_at: Utc::now(),
+            metadata: serde_json::json!({}),
+        })
+    }
+
+    /// Compute stable SHA256 digest from canonical JSON.
+    pub fn compute_digest(fields: &AgentSpecFields) -> Result<String> {
+        // Serialize to JSON and sort keys for deterministic output
+        let json = serde_json::to_value(fields)?;
+        let canonical = canonical_json_string(&json)?;
+
+        let mut hasher = Sha256::new();
+        hasher.update(canonical.as_bytes());
+        Ok(hex::encode(hasher.finalize()))
+    }
+
+    /// Verify that spec_digest matches computed digest.
+    pub fn verify_digest(&self) -> Result<()> {
+        let fields = AgentSpecFields {
+            git_sha: self.git_sha.clone(),
+            graph_digest: self.graph_digest.clone(),
+            prompts_digest: self.prompts_digest.clone(),
+            tools_digest: self.tools_digest.clone(),
+            config_digest: self.config_digest.clone(),
+        };
+
+        let computed = Self::compute_digest(&fields)?;
+        if computed != self.spec_digest {
+            return Err(AivcsError::DigestMismatch {
+                expected: self.spec_digest.clone(),
+                actual: computed,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Convert JSON value to canonical form with sorted keys.
+fn canonical_json_string(value: &serde_json::Value) -> Result<String> {
+    let canonical = sort_json_keys(value);
+    Ok(serde_json::to_string(&canonical)?)
+}
+
+/// Recursively sort JSON object keys to ensure deterministic serialization.
+fn sort_json_keys(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut sorted = serde_json::Map::new();
+            let mut keys: Vec<_> = map.keys().collect();
+            keys.sort();
+            for key in keys {
+                if let Some(v) = map.get(key) {
+                    sorted.insert(key.to_string(), sort_json_keys(v));
+                }
+            }
+            serde_json::Value::Object(sorted)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(sort_json_keys).collect())
+        }
+        other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_agent_spec_serde_roundtrip() {
+        let spec = AgentSpec::new(
+            "abc123def456".to_string(),
+            "graph111".to_string(),
+            "prompts222".to_string(),
+            "tools333".to_string(),
+            "config444".to_string(),
+        )
+        .expect("create spec");
+
+        let json = serde_json::to_string(&spec).expect("serialize");
+        let deserialized: AgentSpec = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(spec, deserialized);
+    }
+
+    #[test]
+    fn test_agent_spec_digest_stable() {
+        let fields1 = AgentSpecFields {
+            git_sha: "abc123".to_string(),
+            graph_digest: "graph111".to_string(),
+            prompts_digest: "prompts222".to_string(),
+            tools_digest: "tools333".to_string(),
+            config_digest: "config444".to_string(),
+        };
+
+        let fields2 = AgentSpecFields {
+            git_sha: "abc123".to_string(),
+            graph_digest: "graph111".to_string(),
+            prompts_digest: "prompts222".to_string(),
+            tools_digest: "tools333".to_string(),
+            config_digest: "config444".to_string(),
+        };
+
+        let digest1 = AgentSpec::compute_digest(&fields1).expect("compute digest 1");
+        let digest2 = AgentSpec::compute_digest(&fields2).expect("compute digest 2");
+
+        assert_eq!(digest1, digest2, "same inputs should produce same digest");
+    }
+
+    #[test]
+    fn test_agent_spec_digest_changes_on_mutation() {
+        let fields1 = AgentSpecFields {
+            git_sha: "abc123".to_string(),
+            graph_digest: "graph111".to_string(),
+            prompts_digest: "prompts222".to_string(),
+            tools_digest: "tools333".to_string(),
+            config_digest: "config444".to_string(),
+        };
+
+        let fields2 = AgentSpecFields {
+            git_sha: "abc123".to_string(),
+            graph_digest: "graph111_MODIFIED".to_string(),
+            prompts_digest: "prompts222".to_string(),
+            tools_digest: "tools333".to_string(),
+            config_digest: "config444".to_string(),
+        };
+
+        let digest1 = AgentSpec::compute_digest(&fields1).expect("compute digest 1");
+        let digest2 = AgentSpec::compute_digest(&fields2).expect("compute digest 2");
+
+        assert_ne!(
+            digest1, digest2,
+            "changed field should produce different digest"
+        );
+    }
+
+    #[test]
+    fn test_agent_spec_verify_digest() {
+        let spec = AgentSpec::new(
+            "abc123".to_string(),
+            "graph111".to_string(),
+            "prompts222".to_string(),
+            "tools333".to_string(),
+            "config444".to_string(),
+        )
+        .expect("create spec");
+
+        assert!(spec.verify_digest().is_ok(), "spec digest should be valid");
+    }
+
+    #[test]
+    fn test_agent_spec_new_rejects_empty_git_sha() {
+        let result = AgentSpec::new(
+            "".to_string(),
+            "graph111".to_string(),
+            "prompts222".to_string(),
+            "tools333".to_string(),
+            "config444".to_string(),
+        );
+
+        assert!(
+            result.is_err(),
+            "creating spec with empty git_sha should fail"
+        );
+    }
+}

--- a/crates/aivcs-core/src/domain/error.rs
+++ b/crates/aivcs-core/src/domain/error.rs
@@ -1,0 +1,52 @@
+//! Domain-level error taxonomy for AIVCS.
+
+/// AIVCS domain errors.
+#[derive(Debug, thiserror::Error)]
+pub enum AivcsError {
+    #[error("invalid agent spec: {0}")]
+    InvalidAgentSpec(String),
+
+    #[error("run not found: {0}")]
+    RunNotFound(uuid::Uuid),
+
+    #[error("eval suite not found: {0}")]
+    EvalSuiteNotFound(uuid::Uuid),
+
+    #[error("release conflict: {0}")]
+    ReleaseConflict(String),
+
+    #[error("digest mismatch: expected {expected}, got {actual}")]
+    DigestMismatch { expected: String, actual: String },
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+/// Result type for AIVCS domain operations.
+pub type Result<T> = std::result::Result<T, AivcsError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_aivcs_error_display() {
+        let err = AivcsError::InvalidAgentSpec("missing git_sha".to_string());
+        assert!(err.to_string().contains("invalid agent spec"));
+
+        let id = uuid::Uuid::new_v4();
+        let err = AivcsError::RunNotFound(id);
+        assert!(err.to_string().contains("run not found"));
+    }
+
+    #[test]
+    fn test_digest_mismatch_error() {
+        let err = AivcsError::DigestMismatch {
+            expected: "abc123".to_string(),
+            actual: "def456".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("abc123"));
+        assert!(msg.contains("def456"));
+    }
+}

--- a/crates/aivcs-core/src/domain/eval.rs
+++ b/crates/aivcs-core/src/domain/eval.rs
@@ -1,0 +1,282 @@
+//! Evaluation suite definitions and scoring configuration.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Enumeration of available scorer types.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case", content = "value")]
+pub enum ScorerType {
+    /// Exact match comparison.
+    ExactMatch,
+
+    /// Semantic similarity (embeddings-based).
+    SemanticSimilarity,
+
+    /// Tool call sequence matching.
+    ToolCallSequence,
+
+    /// Custom scorer extension.
+    Custom(String),
+}
+
+/// Configuration for a single scorer in an evaluation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ScorerConfig {
+    /// Name of this scorer (for reporting).
+    pub name: String,
+
+    /// Type of scorer.
+    pub scorer_type: ScorerType,
+
+    /// Scorer-specific parameters.
+    pub params: serde_json::Value,
+}
+
+/// Thresholds for evaluation pass/fail criteria.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EvalThresholds {
+    /// Minimum pass rate (0.0–1.0) for suite to pass.
+    pub min_pass_rate: f32,
+
+    /// Maximum allowed regression rate (0.0–1.0) vs. baseline.
+    pub max_regression: f32,
+
+    /// If true, stop on first failure.
+    pub fail_fast: bool,
+}
+
+impl Default for EvalThresholds {
+    fn default() -> Self {
+        Self {
+            min_pass_rate: 0.95,
+            max_regression: 0.05,
+            fail_fast: false,
+        }
+    }
+}
+
+/// A single test case within an evaluation suite.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EvalTestCase {
+    /// Unique identifier for this test case.
+    pub case_id: Uuid,
+
+    /// Input provided to the agent.
+    pub inputs: serde_json::Value,
+
+    /// Expected output (optional for scoring-based evals).
+    pub expected: Option<serde_json::Value>,
+
+    /// Tags for categorizing/filtering test cases.
+    pub tags: Vec<String>,
+}
+
+impl EvalTestCase {
+    /// Create a new test case.
+    pub fn new(inputs: serde_json::Value, expected: Option<serde_json::Value>) -> Self {
+        Self {
+            case_id: Uuid::new_v4(),
+            inputs,
+            expected,
+            tags: Vec::new(),
+        }
+    }
+
+    /// Add a tag to this test case.
+    pub fn with_tag(mut self, tag: String) -> Self {
+        self.tags.push(tag);
+        self
+    }
+}
+
+/// A complete evaluation suite for testing an agent.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EvalSuite {
+    /// Unique identifier for this suite.
+    pub suite_id: Uuid,
+
+    /// SHA256 hex digest of canonical suite definition.
+    pub suite_digest: String,
+
+    /// Name of the evaluation.
+    pub name: String,
+
+    /// Version string for the suite.
+    pub version: String,
+
+    /// Test cases in this suite.
+    pub test_cases: Vec<EvalTestCase>,
+
+    /// Scorers to use for evaluation.
+    pub scorers: Vec<ScorerConfig>,
+
+    /// Pass/fail thresholds.
+    pub thresholds: EvalThresholds,
+
+    /// When the suite was created.
+    pub created_at: DateTime<Utc>,
+}
+
+impl EvalSuite {
+    /// Create a new evaluation suite.
+    pub fn new(name: String, version: String) -> Self {
+        Self {
+            suite_id: Uuid::new_v4(),
+            suite_digest: String::new(), // Will be computed on finalization
+            name,
+            version,
+            test_cases: Vec::new(),
+            scorers: Vec::new(),
+            thresholds: EvalThresholds::default(),
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Add a test case to the suite.
+    pub fn add_test_case(mut self, test_case: EvalTestCase) -> Self {
+        self.test_cases.push(test_case);
+        self
+    }
+
+    /// Add a scorer configuration.
+    pub fn add_scorer(mut self, scorer: ScorerConfig) -> Self {
+        self.scorers.push(scorer);
+        self
+    }
+
+    /// Set evaluation thresholds.
+    pub fn with_thresholds(mut self, thresholds: EvalThresholds) -> Self {
+        self.thresholds = thresholds;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_eval_suite_serde_roundtrip() {
+        let suite = EvalSuite::new("test_suite".to_string(), "1.0.0".to_string())
+            .add_test_case(EvalTestCase::new(
+                serde_json::json!({"input": "test"}),
+                Some(serde_json::json!({"output": "expected"})),
+            ))
+            .add_scorer(ScorerConfig {
+                name: "exact_match".to_string(),
+                scorer_type: ScorerType::ExactMatch,
+                params: serde_json::json!({}),
+            });
+
+        let json = serde_json::to_string(&suite).expect("serialize");
+        let deserialized: EvalSuite = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(suite, deserialized);
+    }
+
+    #[test]
+    fn test_eval_thresholds_defaults() {
+        let thresholds = EvalThresholds::default();
+        assert_eq!(thresholds.min_pass_rate, 0.95);
+        assert_eq!(thresholds.max_regression, 0.05);
+        assert!(!thresholds.fail_fast);
+    }
+
+    #[test]
+    fn test_scorer_type_exact_match() {
+        let scorer_type = ScorerType::ExactMatch;
+        let json = serde_json::to_string(&scorer_type).expect("serialize");
+        let deserialized: ScorerType = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(scorer_type, deserialized);
+    }
+
+    #[test]
+    fn test_scorer_type_semantic_similarity() {
+        let scorer_type = ScorerType::SemanticSimilarity;
+        let json = serde_json::to_string(&scorer_type).expect("serialize");
+        let deserialized: ScorerType = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(scorer_type, deserialized);
+    }
+
+    #[test]
+    fn test_scorer_type_custom_roundtrip() {
+        let scorer_type = ScorerType::Custom("my_custom_scorer".to_string());
+        let json = serde_json::to_string(&scorer_type).expect("serialize");
+        let deserialized: ScorerType = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(scorer_type, deserialized);
+    }
+
+    #[test]
+    fn test_scorer_type_tool_call_sequence() {
+        let scorer_type = ScorerType::ToolCallSequence;
+        let json = serde_json::to_string(&scorer_type).expect("serialize");
+        let deserialized: ScorerType = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(scorer_type, deserialized);
+    }
+
+    #[test]
+    fn test_eval_test_case_new() {
+        let test_case = EvalTestCase::new(
+            serde_json::json!({"input": "test"}),
+            Some(serde_json::json!({"output": "expected"})),
+        );
+
+        assert_eq!(test_case.inputs, serde_json::json!({"input": "test"}));
+        assert_eq!(
+            test_case.expected,
+            Some(serde_json::json!({"output": "expected"}))
+        );
+        assert!(test_case.tags.is_empty());
+    }
+
+    #[test]
+    fn test_eval_test_case_with_tag() {
+        let test_case = EvalTestCase::new(
+            serde_json::json!({"input": "test"}),
+            Some(serde_json::json!({"output": "expected"})),
+        )
+        .with_tag("critical".to_string());
+
+        assert_eq!(test_case.tags, vec!["critical"]);
+    }
+
+    #[test]
+    fn test_scorer_config_serde_roundtrip() {
+        let config = ScorerConfig {
+            name: "test_scorer".to_string(),
+            scorer_type: ScorerType::SemanticSimilarity,
+            params: serde_json::json!({"threshold": 0.8}),
+        };
+
+        let json = serde_json::to_string(&config).expect("serialize");
+        let deserialized: ScorerConfig = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn test_eval_suite_fluent_api() {
+        let suite = EvalSuite::new("test".to_string(), "1.0.0".to_string())
+            .add_test_case(EvalTestCase::new(
+                serde_json::json!({"input": "test"}),
+                Some(serde_json::json!({"output": "expected"})),
+            ))
+            .add_scorer(ScorerConfig {
+                name: "scorer1".to_string(),
+                scorer_type: ScorerType::ExactMatch,
+                params: serde_json::json!({}),
+            })
+            .with_thresholds(EvalThresholds {
+                min_pass_rate: 0.90,
+                max_regression: 0.10,
+                fail_fast: true,
+            });
+
+        assert_eq!(suite.test_cases.len(), 1);
+        assert_eq!(suite.scorers.len(), 1);
+        assert_eq!(suite.thresholds.min_pass_rate, 0.90);
+        assert!(suite.thresholds.fail_fast);
+    }
+}

--- a/crates/aivcs-core/src/domain/mod.rs
+++ b/crates/aivcs-core/src/domain/mod.rs
@@ -1,0 +1,20 @@
+//! Domain models for AIVCS.
+//!
+//! Canonical definitions for the core entities:
+//! - `AgentSpec`: Immutable specification of an agent
+//! - `Run`: Execution instance of an agent
+//! - `EvalSuite`: Evaluation framework for testing agents
+//! - `Release`: Deployment records
+
+pub mod agent_spec;
+pub mod error;
+pub mod eval;
+pub mod release;
+pub mod run;
+
+// Re-export main types and errors
+pub use agent_spec::{AgentSpec, AgentSpecFields};
+pub use error::{AivcsError, Result};
+pub use eval::{EvalSuite, EvalTestCase, EvalThresholds, ScorerConfig, ScorerType};
+pub use release::{Release, ReleaseEnvironment, ReleasePointer};
+pub use run::{Event, EventKind, Run, RunStatus};

--- a/crates/aivcs-core/src/domain/release.rs
+++ b/crates/aivcs-core/src/domain/release.rs
@@ -1,0 +1,180 @@
+//! Release and promotion tracking.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Deployment environment for a release.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ReleaseEnvironment {
+    Dev,
+    Staging,
+    Production,
+}
+
+/// A release of an agent into a specific environment.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Release {
+    /// Unique identifier for this release.
+    pub release_id: Uuid,
+
+    /// Name of the agent being released.
+    pub agent_name: String,
+
+    /// Digest of the AgentSpec being released.
+    pub spec_digest: String,
+
+    /// Semantic version of the release.
+    pub version: String,
+
+    /// Target environment.
+    pub environment: ReleaseEnvironment,
+
+    /// When the release was promoted.
+    pub promoted_at: DateTime<Utc>,
+
+    /// User/system that promoted this release.
+    pub promoted_by: String,
+
+    /// Additional metadata (changelog, notes, etc.).
+    pub metadata: serde_json::Value,
+}
+
+impl Release {
+    /// Create a new release.
+    pub fn new(
+        agent_name: String,
+        spec_digest: String,
+        version: String,
+        environment: ReleaseEnvironment,
+        promoted_by: String,
+    ) -> Self {
+        Self {
+            release_id: Uuid::new_v4(),
+            agent_name,
+            spec_digest,
+            version,
+            environment,
+            promoted_at: Utc::now(),
+            promoted_by,
+            metadata: serde_json::json!({}),
+        }
+    }
+}
+
+/// Pointer to the current and previous release for an agent in an environment.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReleasePointer {
+    /// Name of the agent.
+    pub agent_name: String,
+
+    /// Digest of the currently deployed spec.
+    pub current_spec_digest: String,
+
+    /// Digest of the previously deployed spec (for rollback).
+    pub previous_spec_digest: Option<String>,
+
+    /// When the current release was deployed.
+    pub last_updated: DateTime<Utc>,
+}
+
+impl ReleasePointer {
+    /// Create a new release pointer.
+    pub fn new(agent_name: String, current_spec_digest: String) -> Self {
+        Self {
+            agent_name,
+            current_spec_digest,
+            previous_spec_digest: None,
+            last_updated: Utc::now(),
+        }
+    }
+
+    /// Promote a new spec, moving current to previous.
+    pub fn promote(&mut self, new_spec_digest: String) {
+        self.previous_spec_digest = Some(self.current_spec_digest.clone());
+        self.current_spec_digest = new_spec_digest;
+        self.last_updated = Utc::now();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_release_serde_roundtrip() {
+        let release = Release::new(
+            "my_agent".to_string(),
+            "spec_digest_123".to_string(),
+            "1.2.3".to_string(),
+            ReleaseEnvironment::Production,
+            "github-ci".to_string(),
+        );
+
+        let json = serde_json::to_string(&release).expect("serialize");
+        let deserialized: Release = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(release, deserialized);
+    }
+
+    #[test]
+    fn test_release_environment_serde() {
+        let envs = [
+            ReleaseEnvironment::Dev,
+            ReleaseEnvironment::Staging,
+            ReleaseEnvironment::Production,
+        ];
+
+        for env in &envs {
+            let json = serde_json::to_string(env).expect("serialize");
+            let deserialized: ReleaseEnvironment =
+                serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(*env, deserialized);
+        }
+    }
+
+    #[test]
+    fn test_release_pointer_previous_is_none() {
+        let pointer = ReleasePointer::new("my_agent".to_string(), "spec_digest_abc".to_string());
+
+        assert_eq!(pointer.agent_name, "my_agent");
+        assert_eq!(pointer.current_spec_digest, "spec_digest_abc");
+        assert!(pointer.previous_spec_digest.is_none());
+    }
+
+    #[test]
+    fn test_release_pointer_promote() {
+        let mut pointer = ReleasePointer::new("my_agent".to_string(), "spec_digest_v1".to_string());
+
+        pointer.promote("spec_digest_v2".to_string());
+
+        assert_eq!(pointer.current_spec_digest, "spec_digest_v2");
+        assert_eq!(
+            pointer.previous_spec_digest,
+            Some("spec_digest_v1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_release_pointer_serde_roundtrip() {
+        let pointer =
+            ReleasePointer::new("my_agent".to_string(), "spec_digest_current".to_string());
+
+        let json = serde_json::to_string(&pointer).expect("serialize");
+        let deserialized: ReleasePointer = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(pointer, deserialized);
+    }
+
+    #[test]
+    fn test_release_environment_all_variants() {
+        let dev_json = serde_json::to_string(&ReleaseEnvironment::Dev).expect("serialize");
+        let staging_json = serde_json::to_string(&ReleaseEnvironment::Staging).expect("serialize");
+        let prod_json = serde_json::to_string(&ReleaseEnvironment::Production).expect("serialize");
+
+        assert!(dev_json.contains("DEV"));
+        assert!(staging_json.contains("STAGING"));
+        assert!(prod_json.contains("PRODUCTION"));
+    }
+}

--- a/crates/aivcs-core/src/domain/run.rs
+++ b/crates/aivcs-core/src/domain/run.rs
@@ -1,0 +1,253 @@
+//! Run and event tracking.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Status of a run.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum RunStatus {
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+/// A single execution of an agent against an AgentSpec.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Run {
+    /// Unique identifier for this run.
+    pub run_id: Uuid,
+
+    /// Digest of the AgentSpec this run executed.
+    pub agent_spec_digest: String,
+
+    /// Git commit where execution occurred.
+    pub git_sha: String,
+
+    /// When execution started.
+    pub started_at: DateTime<Utc>,
+
+    /// When execution finished (None if still running).
+    pub finished_at: Option<DateTime<Utc>>,
+
+    /// Current execution status.
+    pub status: RunStatus,
+
+    /// Inputs provided to the agent.
+    pub inputs: serde_json::Value,
+
+    /// Outputs from the agent (available after completion).
+    pub outputs: Option<serde_json::Value>,
+
+    /// Digest of final agent state (for deduplication).
+    pub final_state_digest: Option<String>,
+}
+
+impl Run {
+    /// Create a new run.
+    pub fn new(agent_spec_digest: String, git_sha: String, inputs: serde_json::Value) -> Self {
+        Self {
+            run_id: Uuid::new_v4(),
+            agent_spec_digest,
+            git_sha,
+            started_at: Utc::now(),
+            finished_at: None,
+            status: RunStatus::Running,
+            inputs,
+            outputs: None,
+            final_state_digest: None,
+        }
+    }
+}
+
+/// Classification of an event in a run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EventKind {
+    /// Graph execution started.
+    GraphStarted,
+
+    /// Graph execution completed successfully.
+    GraphCompleted,
+
+    /// Graph execution failed.
+    GraphFailed,
+
+    /// Entered a graph node.
+    #[serde(rename = "node_entered")]
+    NodeEntered { node_id: String },
+
+    /// Exited a graph node.
+    #[serde(rename = "node_exited")]
+    NodeExited { node_id: String },
+
+    /// Graph node execution failed.
+    #[serde(rename = "node_failed")]
+    NodeFailed { node_id: String },
+
+    /// Tool was called.
+    #[serde(rename = "tool_called")]
+    ToolCalled { tool_name: String },
+
+    /// Tool returned a result.
+    #[serde(rename = "tool_returned")]
+    ToolReturned { tool_name: String },
+
+    /// Tool execution failed.
+    #[serde(rename = "tool_failed")]
+    ToolFailed { tool_name: String },
+
+    /// Checkpoint marker in execution.
+    #[serde(rename = "checkpoint")]
+    Checkpoint { label: String },
+}
+
+/// A single event in a run's execution trace.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Event {
+    /// Which run this event belongs to.
+    pub run_id: Uuid,
+
+    /// Monotonically increasing sequence number within the run.
+    pub seq: u64,
+
+    /// When the event occurred.
+    pub timestamp: DateTime<Utc>,
+
+    /// Event classification.
+    pub kind: EventKind,
+
+    /// Event-specific payload.
+    pub payload: serde_json::Value,
+}
+
+impl Event {
+    /// Create a new event.
+    pub fn new(run_id: Uuid, seq: u64, kind: EventKind, payload: serde_json::Value) -> Self {
+        Self {
+            run_id,
+            seq,
+            timestamp: Utc::now(),
+            kind,
+            payload,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run_serde_roundtrip() {
+        let run = Run::new(
+            "spec_digest_123".to_string(),
+            "git_sha_abc".to_string(),
+            serde_json::json!({"question": "What is 2+2?"}),
+        );
+
+        let json = serde_json::to_string(&run).expect("serialize");
+        let deserialized: Run = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(run, deserialized);
+    }
+
+    #[test]
+    fn test_run_status_serde() {
+        let statuses = [
+            RunStatus::Running,
+            RunStatus::Completed,
+            RunStatus::Failed,
+            RunStatus::Cancelled,
+        ];
+
+        for status in &statuses {
+            let json = serde_json::to_string(status).expect("serialize");
+            let deserialized: RunStatus = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(*status, deserialized);
+        }
+    }
+
+    #[test]
+    fn test_event_serde_roundtrip_graph_started() {
+        let run_id = Uuid::new_v4();
+        let event = Event::new(run_id, 0, EventKind::GraphStarted, serde_json::json!({}));
+
+        let json = serde_json::to_string(&event).expect("serialize");
+        let deserialized: Event = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(event, deserialized);
+    }
+
+    #[test]
+    fn test_event_serde_roundtrip_node_entered() {
+        let run_id = Uuid::new_v4();
+        let event = Event::new(
+            run_id,
+            1,
+            EventKind::NodeEntered {
+                node_id: "node_42".to_string(),
+            },
+            serde_json::json!({"entry_time_ms": 100}),
+        );
+
+        let json = serde_json::to_string(&event).expect("serialize");
+        let deserialized: Event = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(event, deserialized);
+    }
+
+    #[test]
+    fn test_event_serde_roundtrip_tool_called() {
+        let run_id = Uuid::new_v4();
+        let event = Event::new(
+            run_id,
+            5,
+            EventKind::ToolCalled {
+                tool_name: "search".to_string(),
+            },
+            serde_json::json!({"query": "llm models"}),
+        );
+
+        let json = serde_json::to_string(&event).expect("serialize");
+        let deserialized: Event = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(event, deserialized);
+    }
+
+    #[test]
+    fn test_event_serde_roundtrip_checkpoint() {
+        let run_id = Uuid::new_v4();
+        let event = Event::new(
+            run_id,
+            10,
+            EventKind::Checkpoint {
+                label: "phase_1_complete".to_string(),
+            },
+            serde_json::json!({"phase": 1, "duration_ms": 5000}),
+        );
+
+        let json = serde_json::to_string(&event).expect("serialize");
+        let deserialized: Event = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(event, deserialized);
+    }
+
+    #[test]
+    fn test_run_new_defaults() {
+        let inputs = serde_json::json!({"test": "data"});
+        let run = Run::new(
+            "spec_digest".to_string(),
+            "git_sha".to_string(),
+            inputs.clone(),
+        );
+
+        assert_eq!(run.status, RunStatus::Running);
+        assert!(run.finished_at.is_none());
+        assert!(run.outputs.is_none());
+        assert!(run.final_state_digest.is_none());
+        assert_eq!(run.inputs, inputs);
+    }
+}

--- a/crates/aivcs-core/src/lib.rs
+++ b/crates/aivcs-core/src/lib.rs
@@ -2,26 +2,31 @@
 //!
 //! Re-exports core components for programmatic access to AIVCS functionality.
 
+pub mod domain;
 pub mod parallel;
 
+pub use domain::{
+    AgentSpec, AgentSpecFields, AivcsError, EvalSuite, EvalTestCase, EvalThresholds, Event,
+    EventKind, Release, ReleaseEnvironment, ReleasePointer, Result, Run, RunStatus, ScorerConfig,
+    ScorerType,
+};
+
 pub use oxidized_state::{
-    CommitId, CommitRecord, BranchRecord, SnapshotRecord, MemoryRecord, SurrealHandle,
+    BranchRecord, CommitId, CommitRecord, MemoryRecord, SnapshotRecord, SurrealHandle,
 };
 
 pub use nix_env_manager::{
-    NixHash, HashSource, FlakeMetadata,
-    generate_environment_hash, generate_logic_hash,
-    AtticClient, AtticConfig,
-    is_nix_available, is_attic_available,
+    generate_environment_hash, generate_logic_hash, is_attic_available, is_nix_available,
+    AtticClient, AtticConfig, FlakeMetadata, HashSource, NixHash,
 };
 
 pub use semantic_rag_merge::{
-    VectorStoreDelta, MemoryConflict, AutoResolvedValue, MergeResult,
-    diff_memory_vectors, resolve_conflict_state, synthesize_memory, semantic_merge,
+    diff_memory_vectors, resolve_conflict_state, semantic_merge, synthesize_memory,
+    AutoResolvedValue, MemoryConflict, MergeResult, VectorStoreDelta,
 };
 
 pub use parallel::{
-    fork_agent_parallel, ForkResult, BranchStatus, ParallelConfig, ParallelManager,
+    fork_agent_parallel, BranchStatus, ForkResult, ParallelConfig, ParallelManager,
 };
 
 /// AIVCS version


### PR DESCRIPTION
## Summary

Implement M0-PR2 canonical domain models per issue #12. These are the architectural seams that M1–M4 build on, locked in M0 to prevent cascade churn later.

## Changes

### Domain Models Created
- **AgentSpec**: Immutable specification with SHA256 digest computation
  - Fields: git_sha, graph_digest, prompts_digest, tools_digest, config_digest
  - Canonical JSON serialization with sorted keys for deterministic digests
  - Tests verify digest stability and changes on mutation

- **Run & Event**: Execution tracking
  - Run: status (Running, Completed, Failed, Cancelled), input/output tracking
  - Event: monotonic sequence with EventKind (Graph/Node/Tool operations, Checkpoints)

- **EvalSuite**: Evaluation framework
  - ScorerType: ExactMatch, SemanticSimilarity, ToolCallSequence, Custom
  - ScorerConfig, EvalTestCase, EvalThresholds (min_pass_rate: 0.95, max_regression: 0.05)

- **Release & ReleasePointer**: Deployment tracking
  - Release: agent_name, spec_digest, version, environment (Dev/Staging/Production)
  - ReleasePointer: tracks current & previous spec digest for rollback

- **AivcsError**: Domain-level error taxonomy

### Implementation Details
- All types support serde JSON serialization/deserialization
- Digest computation: canonical JSON → SHA256 → hex
- Full test coverage: 33 tests passing (serde roundtrip, digest stability, defaults)
- Code formatted with rustfmt, clippy clean with -D warnings
- Integration with workspace dependencies: uuid, chrono, sha2, hex, serde, thiserror

## Test Plan

✓ All 33 tests passing:
  - `test_agent_spec_serde_roundtrip` — serialization/deserialization
  - `test_agent_spec_digest_stable` — same inputs produce same digest
  - `test_agent_spec_digest_changes_on_mutation` — digest changes on field modification
  - `test_run_serde_roundtrip`, `test_event_serde_roundtrip_*` — event tracking
  - `test_eval_suite_serde_roundtrip`, `test_scorer_type_*` — evaluation framework
  - `test_release_serde_roundtrip`, `test_release_pointer_*` — deployment tracking

✓ cargo check --workspace (passes)
✓ cargo fmt --check (passes)
✓ cargo clippy --all-targets -- -D warnings (passes)

## PR Details

- **Branch**: codex/featAIVCS-M0B
- **Base**: develop
- **Files**: 6 new domain modules + lib.rs update
- **Closes**: #12