### PR TITLE
feat: M1-PR3 aivcs snapshot CLI with git SHA capture

### DIFF
--- a/crates/aivcs-core/src/domain/error.rs
+++ b/crates/aivcs-core/src/domain/error.rs
@@ -18,6 +18,9 @@ pub enum AivcsError {
     #[error("digest mismatch: expected {expected}, got {actual}")]
     DigestMismatch { expected: String, actual: String },
 
+    #[error("git error: {0}")]
+    GitError(String),
+
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 }

--- a/crates/aivcs-core/src/domain/mod.rs
+++ b/crates/aivcs-core/src/domain/mod.rs
@@ -12,6 +12,7 @@ pub mod error;
 pub mod eval;
 pub mod release;
 pub mod run;
+pub mod snapshot;
 
 // Re-export main types and errors
 pub use agent_spec::{AgentSpec, AgentSpecFields};
@@ -19,3 +20,4 @@ pub use error::{AivcsError, Result};
 pub use eval::{EvalSuite, EvalTestCase, EvalThresholds, ScorerConfig, ScorerType};
 pub use release::{Release, ReleaseEnvironment, ReleasePointer};
 pub use run::{Event, EventKind, Run, RunStatus};
+pub use snapshot::SnapshotMeta;

--- a/crates/aivcs-core/src/domain/snapshot.rs
+++ b/crates/aivcs-core/src/domain/snapshot.rs
@@ -1,0 +1,77 @@
+//! Snapshot metadata linking agent state to a git commit.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Metadata for a CAS-backed snapshot tied to a git commit.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SnapshotMeta {
+    /// CAS digest (hex) of the stored state blob.
+    pub cas_digest: String,
+
+    /// Git HEAD SHA at time of snapshot.
+    pub git_sha: String,
+
+    /// Human-readable message.
+    pub message: String,
+
+    /// Author or agent that created the snapshot.
+    pub author: String,
+
+    /// Branch the snapshot was committed to.
+    pub branch: String,
+
+    /// When the snapshot was created.
+    pub created_at: DateTime<Utc>,
+}
+
+impl SnapshotMeta {
+    pub fn new(
+        cas_digest: String,
+        git_sha: String,
+        message: String,
+        author: String,
+        branch: String,
+    ) -> Self {
+        Self {
+            cas_digest,
+            git_sha,
+            message,
+            author,
+            branch,
+            created_at: Utc::now(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_meta_serde_roundtrip() {
+        let meta = SnapshotMeta::new(
+            "abc123".to_string(),
+            "deadbeef".repeat(5),
+            "test snapshot".to_string(),
+            "agent".to_string(),
+            "main".to_string(),
+        );
+        let json = serde_json::to_string(&meta).unwrap();
+        let deserialized: SnapshotMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(meta, deserialized);
+    }
+
+    #[test]
+    fn snapshot_meta_contains_git_sha() {
+        let sha = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2".to_string();
+        let meta = SnapshotMeta::new(
+            "digest".to_string(),
+            sha.clone(),
+            "msg".to_string(),
+            "agent".to_string(),
+            "main".to_string(),
+        );
+        assert_eq!(meta.git_sha, sha);
+    }
+}

--- a/crates/aivcs-core/src/git.rs
+++ b/crates/aivcs-core/src/git.rs
@@ -1,0 +1,92 @@
+//! Git integration utilities for capturing repository state.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::domain::error::{AivcsError, Result};
+
+/// Capture the HEAD commit SHA from a git repository.
+///
+/// Runs `git rev-parse HEAD` in the given directory. Returns an error if the
+/// directory is not inside a git repository or if git is not available.
+pub fn capture_head_sha(repo_dir: &Path) -> Result<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo_dir)
+        .output()
+        .map_err(|e| AivcsError::GitError(format!("failed to run git: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(AivcsError::GitError(format!(
+            "git rev-parse HEAD failed: {stderr}"
+        )));
+    }
+
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if sha.is_empty() {
+        return Err(AivcsError::GitError(
+            "git rev-parse HEAD returned empty output".to_string(),
+        ));
+    }
+
+    Ok(sha)
+}
+
+/// Check whether a directory is inside a git work tree.
+pub fn is_git_repo(dir: &Path) -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(dir)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command as StdCommand;
+
+    fn make_git_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        StdCommand::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        StdCommand::new("git")
+            .args(["commit", "--allow-empty", "-m", "initial"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        dir
+    }
+
+    #[test]
+    fn capture_head_sha_returns_40_hex_chars() {
+        let repo = make_git_repo();
+        let sha = capture_head_sha(repo.path()).unwrap();
+        assert_eq!(sha.len(), 40, "SHA should be 40 hex chars, got: {sha}");
+        assert!(sha.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn capture_head_sha_fails_outside_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = capture_head_sha(dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn is_git_repo_true_for_repo() {
+        let repo = make_git_repo();
+        assert!(is_git_repo(repo.path()));
+    }
+
+    #[test]
+    fn is_git_repo_false_for_non_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!is_git_repo(dir.path()));
+    }
+}

--- a/crates/aivcs-core/src/lib.rs
+++ b/crates/aivcs-core/src/lib.rs
@@ -4,13 +4,16 @@
 
 pub mod cas;
 pub mod domain;
+pub mod git;
 pub mod parallel;
 
 pub use domain::{
     AgentSpec, AgentSpecFields, AivcsError, EvalSuite, EvalTestCase, EvalThresholds, Event,
     EventKind, Release, ReleaseEnvironment, ReleasePointer, Result, Run, RunStatus, ScorerConfig,
-    ScorerType,
+    ScorerType, SnapshotMeta,
 };
+
+pub use git::{capture_head_sha, is_git_repo};
 
 pub use oxidized_state::{
     BranchRecord, CommitId, CommitRecord, MemoryRecord, SnapshotRecord, SurrealHandle,


### PR DESCRIPTION
## Summary
- Add `git` module to `aivcs-core` with `capture_head_sha()` and `is_git_repo()` for linking snapshots to git HEAD
- Add `SnapshotMeta` domain type for CAS-backed snapshot metadata
- Update `aivcs snapshot` command:
  - `--git-sha` flag (auto-detected from cwd if omitted)
  - `--cas-dir` flag (default: `.aivcs/cas`)
  - State content stored in `FsCasStore` alongside SurrealDB
- Add `GitError` variant to `AivcsError`
- 8 new tests (git SHA capture, CAS roundtrip, snapshot-to-commit linking)

## Test plan
- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — 145 tests pass
- [x] `test_snapshot_linked_to_git_sha` — verifies CAS storage + git SHA binding
- [x] `test_snapshot_auto_detects_git_sha_in_repo` — verifies auto-detection
- [x] 4 unit tests for `git::capture_head_sha` and `git::is_git_repo`
- [x] 2 unit tests for `SnapshotMeta` serde roundtrip

Closes #16
Refs #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)