### PR TITLE
feat: node path extraction and divergence diff (M2-PR2)

### DIFF
--- a/crates/aivcs-core/src/diff/mod.rs
+++ b/crates/aivcs-core/src/diff/mod.rs
@@ -1,1 +1,2 @@
+pub mod node_paths;
 pub mod tool_calls;

--- a/crates/aivcs-core/src/diff/node_paths.rs
+++ b/crates/aivcs-core/src/diff/node_paths.rs
@@ -1,0 +1,95 @@
+use oxidized_state::RunEvent;
+
+/// A single node step extracted from a `RunEvent` stream.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NodeStep {
+    pub seq: u64,
+    pub node_id: String,
+}
+
+/// The divergence point between two node traversal paths.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NodeDivergence {
+    /// Node IDs that both paths share before the first mismatch.
+    pub common_prefix: Vec<String>,
+    /// Remaining steps only in path A after the divergence point.
+    pub tail_a: Vec<NodeStep>,
+    /// Remaining steps only in path B after the divergence point.
+    pub tail_b: Vec<NodeStep>,
+}
+
+/// The result of diffing two node traversal paths.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NodePathDiff {
+    pub divergence: Option<NodeDivergence>,
+}
+
+impl NodePathDiff {
+    pub fn is_empty(&self) -> bool {
+        self.divergence.is_none()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+/// Extract the ordered node traversal path from a run event stream.
+///
+/// Only `"node_entered"` events are considered. Events without a valid
+/// `payload["node_id"]` string are silently skipped.
+pub fn extract_node_path(events: &[RunEvent]) -> Vec<NodeStep> {
+    events
+        .iter()
+        .filter(|e| e.kind == "node_entered")
+        .filter_map(|e| {
+            let node_id = e
+                .payload
+                .get("node_id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())?;
+            Some(NodeStep {
+                seq: e.seq,
+                node_id,
+            })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Diff two ordered `RunEvent` sequences by their node traversal paths.
+///
+/// Extracts `"node_entered"` events from each sequence, then walks both
+/// paths in lockstep to find the first divergence point. Returns
+/// `NodePathDiff { divergence: None }` when the paths are identical.
+pub fn diff_node_paths(a: &[RunEvent], b: &[RunEvent]) -> NodePathDiff {
+    let path_a = extract_node_path(a);
+    let path_b = extract_node_path(b);
+
+    let mut common_prefix = Vec::new();
+    let mut i = 0;
+
+    while i < path_a.len() && i < path_b.len() {
+        if path_a[i].node_id == path_b[i].node_id {
+            common_prefix.push(path_a[i].node_id.clone());
+            i += 1;
+        } else {
+            break;
+        }
+    }
+
+    if i == path_a.len() && i == path_b.len() {
+        NodePathDiff { divergence: None }
+    } else {
+        NodePathDiff {
+            divergence: Some(NodeDivergence {
+                common_prefix,
+                tail_a: path_a[i..].to_vec(),
+                tail_b: path_b[i..].to_vec(),
+            }),
+        }
+    }
+}

--- a/crates/aivcs-core/src/lib.rs
+++ b/crates/aivcs-core/src/lib.rs
@@ -38,6 +38,9 @@ pub use parallel::{
     fork_agent_parallel, BranchStatus, ForkResult, ParallelConfig, ParallelManager,
 };
 
+pub use diff::node_paths::{
+    diff_node_paths, extract_node_path, NodeDivergence, NodePathDiff, NodeStep,
+};
 pub use diff::tool_calls::{diff_tool_calls, ParamDelta, ToolCall, ToolCallChange, ToolCallDiff};
 pub use recording::GraphRunRecorder;
 

--- a/crates/aivcs-core/tests/node_path_diff.rs
+++ b/crates/aivcs-core/tests/node_path_diff.rs
@@ -1,0 +1,146 @@
+use aivcs_core::{diff_node_paths, extract_node_path, NodeStep};
+use chrono::Utc;
+use oxidized_state::RunEvent;
+use serde_json::json;
+
+fn node_event(seq: u64, node_id: &str) -> RunEvent {
+    RunEvent {
+        seq,
+        kind: "node_entered".to_string(),
+        payload: json!({ "node_id": node_id }),
+        timestamp: Utc::now(),
+    }
+}
+
+fn non_node_event(seq: u64, kind: &str) -> RunEvent {
+    RunEvent {
+        seq,
+        kind: kind.to_string(),
+        payload: json!({ "some_key": "value" }),
+        timestamp: Utc::now(),
+    }
+}
+
+#[test]
+fn identical_paths_produce_no_divergence() {
+    let events = vec![node_event(1, "A"), node_event(2, "B"), node_event(3, "C")];
+    let diff = diff_node_paths(&events, &events);
+    assert!(
+        diff.is_empty(),
+        "identical paths should produce no divergence"
+    );
+}
+
+#[test]
+fn diverges_at_first_step() {
+    let a = vec![node_event(1, "A"), node_event(2, "B")];
+    let b = vec![node_event(1, "X"), node_event(2, "Y")];
+    let diff = diff_node_paths(&a, &b);
+
+    let div = diff.divergence.expect("should have divergence");
+    assert!(div.common_prefix.is_empty());
+    assert_eq!(div.tail_a.len(), 2);
+    assert_eq!(div.tail_b.len(), 2);
+    assert_eq!(div.tail_a[0].node_id, "A");
+    assert_eq!(div.tail_b[0].node_id, "X");
+}
+
+#[test]
+fn diverges_mid_path() {
+    let a = vec![node_event(1, "A"), node_event(2, "B"), node_event(3, "C")];
+    let b = vec![node_event(1, "A"), node_event(2, "B"), node_event(3, "D")];
+    let diff = diff_node_paths(&a, &b);
+
+    let div = diff.divergence.expect("should have divergence");
+    assert_eq!(div.common_prefix, vec!["A", "B"]);
+    assert_eq!(div.tail_a.len(), 1);
+    assert_eq!(div.tail_a[0].node_id, "C");
+    assert_eq!(div.tail_b.len(), 1);
+    assert_eq!(div.tail_b[0].node_id, "D");
+}
+
+#[test]
+fn path_a_is_prefix_of_b() {
+    let a = vec![node_event(1, "A"), node_event(2, "B")];
+    let b = vec![node_event(1, "A"), node_event(2, "B"), node_event(3, "C")];
+    let diff = diff_node_paths(&a, &b);
+
+    let div = diff.divergence.expect("should have divergence");
+    assert_eq!(div.common_prefix, vec!["A", "B"]);
+    assert!(div.tail_a.is_empty());
+    assert_eq!(div.tail_b.len(), 1);
+    assert_eq!(div.tail_b[0].node_id, "C");
+}
+
+#[test]
+fn path_b_is_prefix_of_a() {
+    let a = vec![node_event(1, "A"), node_event(2, "B"), node_event(3, "C")];
+    let b = vec![node_event(1, "A"), node_event(2, "B")];
+    let diff = diff_node_paths(&a, &b);
+
+    let div = diff.divergence.expect("should have divergence");
+    assert_eq!(div.common_prefix, vec!["A", "B"]);
+    assert_eq!(div.tail_a.len(), 1);
+    assert_eq!(div.tail_a[0].node_id, "C");
+    assert!(div.tail_b.is_empty());
+}
+
+#[test]
+fn empty_paths_produce_no_divergence() {
+    let empty: Vec<RunEvent> = vec![];
+    let diff = diff_node_paths(&empty, &empty);
+    assert!(diff.is_empty(), "empty paths should produce no divergence");
+}
+
+#[test]
+fn non_node_events_are_filtered_out() {
+    let a = vec![
+        non_node_event(1, "tool_called"),
+        node_event(2, "A"),
+        non_node_event(3, "node_exited"),
+        node_event(4, "B"),
+    ];
+    let b = vec![node_event(1, "A"), node_event(2, "B")];
+    let diff = diff_node_paths(&a, &b);
+    assert!(
+        diff.is_empty(),
+        "non-node events should be filtered, leaving identical paths"
+    );
+
+    // Also verify extract_node_path directly
+    let path = extract_node_path(&a);
+    assert_eq!(path.len(), 2);
+    assert_eq!(path[0].node_id, "A");
+    assert_eq!(path[1].node_id, "B");
+}
+
+#[test]
+fn malformed_node_events_are_skipped() {
+    let malformed = RunEvent {
+        seq: 1,
+        kind: "node_entered".to_string(),
+        payload: json!({ "some_key": "no_node_id_here" }),
+        timestamp: Utc::now(),
+    };
+    let valid = node_event(2, "A");
+
+    let a = vec![malformed, valid.clone()];
+    let b = vec![valid];
+    let diff = diff_node_paths(&a, &b);
+    assert!(
+        diff.is_empty(),
+        "malformed events without node_id should be skipped, got: {:?}",
+        diff.divergence
+    );
+
+    // Verify extraction skips malformed
+    let path = extract_node_path(&a);
+    assert_eq!(path.len(), 1);
+    assert_eq!(
+        path[0],
+        NodeStep {
+            seq: 2,
+            node_id: "A".to_string()
+        }
+    );
+}


### PR DESCRIPTION
## Summary
- Add `extract_node_path` and `diff_node_paths` functions to the semantic diff engine
- Extract ordered node traversal paths from `node_entered` events and find the first divergence point between two runs
- Follows identical patterns to M2-PR1 (`diff/tool_calls.rs`)

## Changes
| File | Change |
|------|--------|
| `crates/aivcs-core/src/diff/node_paths.rs` | NEW — `NodeStep`, `NodeDivergence`, `NodePathDiff` types + extraction/diff algorithm |
| `crates/aivcs-core/src/diff/mod.rs` | +`pub mod node_paths;` |
| `crates/aivcs-core/src/lib.rs` | +5 re-exports |
| `crates/aivcs-core/tests/node_path_diff.rs` | NEW — 8 tests |

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — all 100 tests pass (8 new + 92 existing)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)