### PR TITLE
fix: replace .expect() with error propagation in FsCasStore::put

### DIFF
--- a/crates/aivcs-core/src/cas/fs.rs
+++ b/crates/aivcs-core/src/cas/fs.rs
@@ -36,7 +36,12 @@ impl CasStore for FsCasStore {
             return Ok(digest);
         }
 
-        let shard_dir = path.parent().expect("blob path always has parent");
+        let shard_dir = path.parent().ok_or_else(|| {
+            CasError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "blob path has no parent directory",
+            ))
+        })?;
         fs::create_dir_all(shard_dir)?;
 
         // Atomic write: write to temp file in the same directory, then rename.


### PR DESCRIPTION
## Summary
- Replace `.expect("blob path always has parent")` with proper `?` error propagation in `FsCasStore::put`
- Returns a descriptive `CasError::Io` instead of panicking on unexpected path structure

Cherry-picked from the one valuable fix in #53 (now closed as stale).

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)