### PR TITLE
feat: merge gate rules engine (M3-PR2)

### DIFF
--- a/crates/aivcs-core/src/gate.rs
+++ b/crates/aivcs-core/src/gate.rs
@@ -1,0 +1,222 @@
+//! Merge gate rules engine.
+//!
+//! Evaluates [`CaseResult`] vectors against [`GateRuleSet`] configurations to
+//! produce a [`GateVerdict`] — the pass/fail decision that blocks or allows a
+//! merge. Supports threshold checks, regression limits, fail-fast, and
+//! tag-based required-pass rules.
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::eval::EvalThresholds;
+
+// ---------------------------------------------------------------------------
+// Eval result types (input to the gate)
+// ---------------------------------------------------------------------------
+
+/// Result of evaluating a single test case.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CaseResult {
+    /// Identifier for the test case.
+    pub case_id: String,
+    /// Score in 0.0–1.0.
+    pub score: f32,
+    /// Whether this case passed.
+    pub passed: bool,
+    /// Tags inherited from the `EvalTestCase`.
+    pub tags: Vec<String>,
+}
+
+/// Aggregated report from an eval run — the input to the gate engine.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EvalReport {
+    /// Per-case results.
+    pub case_results: Vec<CaseResult>,
+    /// Pass rate (0.0–1.0) from the eval runner.
+    pub pass_rate: f32,
+    /// Optional baseline pass rate for regression detection.
+    pub baseline_pass_rate: Option<f32>,
+}
+
+// ---------------------------------------------------------------------------
+// Gate rules
+// ---------------------------------------------------------------------------
+
+/// A single gate rule that can block a merge.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum GateRule {
+    /// Pass rate must meet or exceed `EvalThresholds::min_pass_rate`.
+    MinPassRate,
+    /// Regression (baseline − current) must not exceed `EvalThresholds::max_regression`.
+    MaxRegression,
+    /// All cases with the given tag must pass.
+    RequireTag { tag: String },
+}
+
+/// A set of gate rules plus the thresholds they reference.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GateRuleSet {
+    pub thresholds: EvalThresholds,
+    pub rules: Vec<GateRule>,
+}
+
+impl GateRuleSet {
+    /// Create a rule set with default thresholds and the standard rules
+    /// (`MinPassRate` + `MaxRegression`).
+    pub fn standard() -> Self {
+        Self {
+            thresholds: EvalThresholds::default(),
+            rules: vec![GateRule::MinPassRate, GateRule::MaxRegression],
+        }
+    }
+
+    /// Add a rule.
+    pub fn with_rule(mut self, rule: GateRule) -> Self {
+        self.rules.push(rule);
+        self
+    }
+
+    /// Override thresholds.
+    pub fn with_thresholds(mut self, thresholds: EvalThresholds) -> Self {
+        self.thresholds = thresholds;
+        self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Verdict
+// ---------------------------------------------------------------------------
+
+/// A single rule violation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Violation {
+    /// Which rule was violated.
+    pub rule: GateRule,
+    /// Human-readable explanation.
+    pub reason: String,
+}
+
+/// The outcome of evaluating a gate rule set against an eval report.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GateVerdict {
+    /// Whether the gate passed (no violations).
+    pub passed: bool,
+    /// Violations found (empty when passed).
+    pub violations: Vec<Violation>,
+}
+
+impl GateVerdict {
+    fn pass() -> Self {
+        Self {
+            passed: true,
+            violations: Vec::new(),
+        }
+    }
+
+    fn fail(violations: Vec<Violation>) -> Self {
+        Self {
+            passed: false,
+            violations,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Engine
+// ---------------------------------------------------------------------------
+
+/// Evaluate an [`EvalReport`] against a [`GateRuleSet`], returning a [`GateVerdict`].
+///
+/// When `thresholds.fail_fast` is true, evaluation stops at the first violation.
+pub fn evaluate_gate(rule_set: &GateRuleSet, report: &EvalReport) -> GateVerdict {
+    let mut violations = Vec::new();
+    let fail_fast = rule_set.thresholds.fail_fast;
+
+    for rule in &rule_set.rules {
+        if let Some(v) = check_rule(rule, &rule_set.thresholds, report) {
+            violations.push(v);
+            if fail_fast {
+                return GateVerdict::fail(violations);
+            }
+        }
+    }
+
+    if violations.is_empty() {
+        GateVerdict::pass()
+    } else {
+        GateVerdict::fail(violations)
+    }
+}
+
+fn check_rule(
+    rule: &GateRule,
+    thresholds: &EvalThresholds,
+    report: &EvalReport,
+) -> Option<Violation> {
+    match rule {
+        GateRule::MinPassRate => {
+            if report.pass_rate < thresholds.min_pass_rate {
+                Some(Violation {
+                    rule: rule.clone(),
+                    reason: format!(
+                        "pass rate {:.2}% < required {:.2}%",
+                        report.pass_rate * 100.0,
+                        thresholds.min_pass_rate * 100.0,
+                    ),
+                })
+            } else {
+                None
+            }
+        }
+        GateRule::MaxRegression => {
+            if let Some(baseline) = report.baseline_pass_rate {
+                let regression = baseline - report.pass_rate;
+                if regression > thresholds.max_regression {
+                    Some(Violation {
+                        rule: rule.clone(),
+                        reason: format!(
+                            "regression {:.2}% > allowed {:.2}% (baseline {:.2}% → current {:.2}%)",
+                            regression * 100.0,
+                            thresholds.max_regression * 100.0,
+                            baseline * 100.0,
+                            report.pass_rate * 100.0,
+                        ),
+                    })
+                } else {
+                    None
+                }
+            } else {
+                // No baseline → no regression to check
+                None
+            }
+        }
+        GateRule::RequireTag { tag } => {
+            let tagged: Vec<&CaseResult> = report
+                .case_results
+                .iter()
+                .filter(|c| c.tags.contains(tag))
+                .collect();
+
+            let failed: Vec<&str> = tagged
+                .iter()
+                .filter(|c| !c.passed)
+                .map(|c| c.case_id.as_str())
+                .collect();
+
+            if failed.is_empty() {
+                None
+            } else {
+                Some(Violation {
+                    rule: rule.clone(),
+                    reason: format!(
+                        "{} of {} cases tagged '{}' failed: [{}]",
+                        failed.len(),
+                        tagged.len(),
+                        tag,
+                        failed.join(", "),
+                    ),
+                })
+            }
+        }
+    }
+}

--- a/crates/aivcs-core/src/lib.rs
+++ b/crates/aivcs-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cas;
 pub mod diff;
 pub mod domain;
 pub mod event_adapter;
+pub mod gate;
 pub mod git;
 pub mod parallel;
 pub mod recording;
@@ -55,6 +56,9 @@ pub use diff::state_diff::{
     CHECKPOINT_SAVED_KIND,
 };
 pub use diff::tool_calls::{diff_tool_calls, ParamDelta, ToolCall, ToolCallChange, ToolCallDiff};
+pub use gate::{
+    evaluate_gate, CaseResult, EvalReport, GateRule, GateRuleSet, GateVerdict, Violation,
+};
 pub use recording::GraphRunRecorder;
 pub use replay::{replay_run, ReplaySummary};
 

--- a/crates/aivcs-core/tests/merge_gate.rs
+++ b/crates/aivcs-core/tests/merge_gate.rs
@@ -1,0 +1,253 @@
+use aivcs_core::{
+    evaluate_gate, CaseResult, EvalReport, EvalThresholds, GateRule, GateRuleSet, GateVerdict,
+};
+
+fn passing_case(id: &str, tags: &[&str]) -> CaseResult {
+    CaseResult {
+        case_id: id.to_string(),
+        score: 1.0,
+        passed: true,
+        tags: tags.iter().map(|t| t.to_string()).collect(),
+    }
+}
+
+fn failing_case(id: &str, tags: &[&str]) -> CaseResult {
+    CaseResult {
+        case_id: id.to_string(),
+        score: 0.0,
+        passed: false,
+        tags: tags.iter().map(|t| t.to_string()).collect(),
+    }
+}
+
+fn report(pass_rate: f32, cases: Vec<CaseResult>, baseline: Option<f32>) -> EvalReport {
+    EvalReport {
+        case_results: cases,
+        pass_rate,
+        baseline_pass_rate: baseline,
+    }
+}
+
+// ---- MinPassRate rule ----
+
+#[test]
+fn all_passing_meets_threshold() {
+    let rule_set = GateRuleSet::standard();
+    let r = report(1.0, vec![passing_case("c1", &[])], None);
+    let verdict = evaluate_gate(&rule_set, &r);
+    assert!(verdict.passed);
+    assert!(verdict.violations.is_empty());
+}
+
+#[test]
+fn below_min_pass_rate_fails() {
+    let rule_set = GateRuleSet::standard();
+    let r = report(
+        0.5,
+        vec![passing_case("c1", &[]), failing_case("c2", &[])],
+        None,
+    );
+    let verdict = evaluate_gate(&rule_set, &r);
+    assert!(!verdict.passed);
+    assert!(verdict
+        .violations
+        .iter()
+        .any(|v| matches!(&v.rule, GateRule::MinPassRate)));
+}
+
+#[test]
+fn exactly_at_threshold_passes() {
+    let rule_set = GateRuleSet::standard(); // min_pass_rate = 0.95
+    let r = report(0.95, vec![passing_case("c1", &[])], None);
+    let verdict = evaluate_gate(&rule_set, &r);
+    assert!(verdict.passed);
+}
+
+// ---- MaxRegression rule ----
+
+#[test]
+fn no_baseline_skips_regression_check() {
+    let rule_set = GateRuleSet::standard();
+    let r = report(0.96, vec![passing_case("c1", &[])], None);
+    let verdict = evaluate_gate(&rule_set, &r);
+    assert!(verdict.passed, "no baseline should skip regression rule");
+}
+
+#[test]
+fn regression_within_limit_passes() {
+    let rule_set = GateRuleSet::standard(); // max_regression = 0.05
+                                            // baseline 1.0 → current 0.96 = regression 0.04 < 0.05
+    let r = report(0.96, vec![passing_case("c1", &[])], Some(1.0));
+    let verdict = evaluate_gate(&rule_set, &r);
+    assert!(verdict.passed);
+}
+
+#[test]
+fn regression_exceeding_limit_fails() {
+    // Isolate regression rule: baseline 1.0 → current 0.90 = regression 0.10 > 0.05
+    let rule_set = GateRuleSet {
+        thresholds: EvalThresholds {
+            min_pass_rate: 0.0,
+            max_regression: 0.05,
+            fail_fast: false,
+        },
+        rules: vec![GateRule::MaxRegression],
+    };
+    let r = report(0.90, vec![], Some(1.0));
+    let verdict = evaluate_gate(&rule_set, &r);
+    assert!(!verdict.passed);
+    assert!(verdict
+        .violations
+        .iter()
+        .any(|v| matches!(&v.rule, GateRule::MaxRegression)));
+}
+
+// ---- RequireTag rule ----
+
+#[test]
+fn required_tag_all_pass() {
+    let rule_set = GateRuleSet {
+        thresholds: EvalThresholds::default(),
+        rules: vec![GateRule::RequireTag {
+            tag: "critical".to_string(),
+        }],
+    };
+    let r = report(
+        1.0,
+        vec![
+            passing_case("c1", &["critical"]),
+            passing_case("c2", &["critical"]),
+            passing_case("c3", &[]),
+        ],
+        None,
+    );
+    let verdict = evaluate_gate(&rule_set, &r);
+    assert!(verdict.passed);
+}
+
+#[test]
+fn required_tag_some_fail() {
+    let rule_set = GateRuleSet {
+        thresholds: EvalThresholds {
+            min_pass_rate: 0.0,
+            max_regression: 1.0,
+            fail_fast: false,
+        },
+        rules: vec![GateRule::RequireTag {
+            tag: "critical".to_string(),
+        }],
+    };
+    let r = report(
+        0.5,
+        vec![
+            passing_case("c1", &["critical"]),
+            failing_case("c2", &["critical"]),
+            failing_case("c3", &[]),
+        ],
+        None,
+    );
+    let verdict = evaluate_gate(&rule_set, &r);
+    assert!(!verdict.passed);
+    let tag_violation = verdict
+        .violations
+        .iter()
+        .find(|v| matches!(&v.rule, GateRule::RequireTag { .. }))
+        .expect("should have RequireTag violation");
+    assert!(tag_violation.reason.contains("c2"));
+    assert!(!tag_violation.reason.contains("c3")); // c3 is not tagged critical
+}
+
+// ---- Fail-fast ----
+
+#[test]
+fn fail_fast_stops_at_first_violation() {
+    let rule_set = GateRuleSet {
+        thresholds: EvalThresholds {
+            min_pass_rate: 0.99,
+            max_regression: 0.01,
+            fail_fast: true,
+        },
+        rules: vec![
+            GateRule::MinPassRate,
+            GateRule::MaxRegression,
+            GateRule::RequireTag {
+                tag: "critical".to_string(),
+            },
+        ],
+    };
+    // This report violates all three rules
+    let r = report(0.50, vec![failing_case("c1", &["critical"])], Some(1.0));
+    let verdict = evaluate_gate(&rule_set, &r);
+    assert!(!verdict.passed);
+    assert_eq!(
+        verdict.violations.len(),
+        1,
+        "fail_fast should stop at first violation"
+    );
+}
+
+// ---- Edge cases ----
+
+#[test]
+fn empty_rules_always_passes() {
+    let rule_set = GateRuleSet {
+        thresholds: EvalThresholds::default(),
+        rules: vec![],
+    };
+    let r = report(0.0, vec![failing_case("c1", &[])], Some(1.0));
+    let verdict = evaluate_gate(&rule_set, &r);
+    assert!(verdict.passed, "no rules means gate always passes");
+}
+
+#[test]
+fn empty_cases_with_zero_pass_rate_checked() {
+    let rule_set = GateRuleSet::standard();
+    let r = report(0.0, vec![], None);
+    let verdict = evaluate_gate(&rule_set, &r);
+    assert!(!verdict.passed, "0% pass rate should fail MinPassRate");
+}
+
+#[test]
+fn standard_constructor_has_two_rules() {
+    let rule_set = GateRuleSet::standard();
+    assert_eq!(rule_set.rules.len(), 2);
+    assert!(matches!(rule_set.rules[0], GateRule::MinPassRate));
+    assert!(matches!(rule_set.rules[1], GateRule::MaxRegression));
+}
+
+#[test]
+fn multiple_violations_collected_without_fail_fast() {
+    let rule_set = GateRuleSet {
+        thresholds: EvalThresholds {
+            min_pass_rate: 0.99,
+            max_regression: 0.01,
+            fail_fast: false,
+        },
+        rules: vec![GateRule::MinPassRate, GateRule::MaxRegression],
+    };
+    let r = report(0.50, vec![], Some(1.0));
+    let verdict = evaluate_gate(&rule_set, &r);
+    assert!(!verdict.passed);
+    assert_eq!(
+        verdict.violations.len(),
+        2,
+        "both violations should be collected"
+    );
+}
+
+#[test]
+fn with_rule_builder_appends() {
+    let rule_set = GateRuleSet::standard().with_rule(GateRule::RequireTag {
+        tag: "smoke".to_string(),
+    });
+    assert_eq!(rule_set.rules.len(), 3);
+}
+
+#[test]
+fn verdict_pass_returns_true() {
+    let v = GateVerdict {
+        passed: true,
+        violations: vec![],
+    };
+    assert!(v.passed);
+}


### PR DESCRIPTION
## Summary
- Add `evaluate_gate` function that checks an `EvalReport` against a `GateRuleSet` to produce a `GateVerdict`
- Three rule types: `MinPassRate`, `MaxRegression`, `RequireTag`
- Supports fail-fast mode (stop at first violation) and fluent builder API
- Types: `GateRuleSet`, `GateRule`, `GateVerdict`, `Violation`, `EvalReport`, `CaseResult`

## Changes
| File | Change |
|------|--------|
| `crates/aivcs-core/src/gate.rs` | NEW — rule engine types + `evaluate_gate` |
| `crates/aivcs-core/src/lib.rs` | +`pub mod gate;` + 7 re-exports |
| `crates/aivcs-core/tests/merge_gate.rs` | NEW — 15 tests |

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — all tests pass (15 new + existing)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)