### PR TITLE
feat: PR summary reporter artifacts (M3-PR4)

### DIFF
--- a/crates/aivcs-core/src/diff/mod.rs
+++ b/crates/aivcs-core/src/diff/mod.rs
@@ -1,4 +1,436 @@
+//! Diffing infrastructure for run comparison.
+//!
+//! This module provides:
+//! - LCS-based tool-call sequence diffing (`DiffSummary`, `diff_tool_calls`)
+//! - Per-tool-name grouped diffing (`tool_calls` submodule)
+//! - Node path divergence detection (`node_paths` submodule)
+//! - Scoped state diffing (`state_diff` submodule)
+
 pub mod lcs_diff;
 pub mod node_paths;
 pub mod state_diff;
 pub mod tool_calls;
+
+use oxidized_state::storage_traits::RunEvent;
+use serde_json::Value;
+
+/// A single tool call extracted from a run's events (LCS-based diff).
+#[derive(Debug, Clone)]
+pub struct ToolCallEntry {
+    /// Sequence number from the run event
+    pub seq: u64,
+    /// Tool name extracted from payload["tool_name"]
+    pub tool_name: String,
+    /// Full event payload
+    pub payload: Value,
+}
+
+/// A parameter change between two tool call versions (LCS-based diff).
+#[derive(Debug, Clone)]
+pub struct ParamChange {
+    /// RFC 6901 JSON Pointer path (e.g., "/query", "/context/0")
+    pub pointer: String,
+    /// Value in run A
+    pub value_a: Value,
+    /// Value in run B
+    pub value_b: Value,
+}
+
+/// A single change in the tool-call sequence (LCS-based diff).
+#[derive(Debug, Clone)]
+pub enum LcsToolCallChange {
+    /// Tool call added in B but not in A
+    Added { entry: ToolCallEntry },
+    /// Tool call removed in B (was in A)
+    Removed { entry: ToolCallEntry },
+    /// Tool call reordered between A and B
+    Reordered {
+        tool_name: String,
+        seq_a: u64,
+        seq_b: u64,
+    },
+    /// Tool call exists in both, but parameters differ
+    ParamDelta {
+        tool_name: String,
+        seq_a: u64,
+        seq_b: u64,
+        changes: Vec<ParamChange>,
+    },
+}
+
+/// Summary of differences between two runs' tool-call sequences (LCS-based).
+#[derive(Debug, Clone)]
+pub struct DiffSummary {
+    pub run_id_a: String,
+    pub run_id_b: String,
+    pub changes: Vec<LcsToolCallChange>,
+    pub identical: bool,
+}
+
+/// Extract tool-call entries from a run's event list.
+fn extract_lcs_tool_calls(events: &[RunEvent]) -> Vec<ToolCallEntry> {
+    events
+        .iter()
+        .filter(|e| e.kind == "tool_called")
+        .map(|e| ToolCallEntry {
+            seq: e.seq,
+            tool_name: e
+                .payload
+                .get("tool_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string(),
+            payload: e.payload.clone(),
+        })
+        .collect()
+}
+
+/// Compute the Longest Common Subsequence (LCS) of tool names.
+fn lcs_alignment(calls_a: &[ToolCallEntry], calls_b: &[ToolCallEntry]) -> Vec<(usize, usize)> {
+    let m = calls_a.len();
+    let n = calls_b.len();
+
+    if m == 0 || n == 0 {
+        return Vec::new();
+    }
+
+    let mut dp = vec![vec![0usize; n + 1]; m + 1];
+
+    for i in 1..=m {
+        for j in 1..=n {
+            if calls_a[i - 1].tool_name == calls_b[j - 1].tool_name {
+                dp[i][j] = dp[i - 1][j - 1] + 1;
+            } else {
+                dp[i][j] = dp[i][j - 1].max(dp[i - 1][j]);
+            }
+        }
+    }
+
+    let mut alignment = Vec::new();
+    let mut i = m;
+    let mut j = n;
+
+    while i > 0 && j > 0 {
+        if calls_a[i - 1].tool_name == calls_b[j - 1].tool_name {
+            alignment.push((i - 1, j - 1));
+            i -= 1;
+            j -= 1;
+        } else if dp[i][j - 1] > dp[i - 1][j] {
+            j -= 1;
+        } else {
+            i -= 1;
+        }
+    }
+
+    alignment.reverse();
+    alignment
+}
+
+/// Recursively compute JSON differences.
+fn json_diff(prefix: &str, val_a: &Value, val_b: &Value) -> Vec<ParamChange> {
+    if val_a == val_b {
+        return Vec::new();
+    }
+
+    match (val_a, val_b) {
+        (Value::Object(obj_a), Value::Object(obj_b)) => {
+            let mut changes = Vec::new();
+            let mut keys = std::collections::HashSet::new();
+            keys.extend(obj_a.keys().cloned());
+            keys.extend(obj_b.keys().cloned());
+
+            for key in keys {
+                let val_a_inner = obj_a.get(&key).unwrap_or(&Value::Null);
+                let val_b_inner = obj_b.get(&key).unwrap_or(&Value::Null);
+                let path = if prefix.is_empty() {
+                    format!("/{}", key)
+                } else {
+                    format!("{}/{}", prefix, key)
+                };
+                changes.extend(json_diff(&path, val_a_inner, val_b_inner));
+            }
+            changes
+        }
+        (Value::Array(arr_a), Value::Array(arr_b)) => {
+            let mut changes = Vec::new();
+            let max_len = arr_a.len().max(arr_b.len());
+
+            for i in 0..max_len {
+                let val_a_inner = arr_a.get(i).unwrap_or(&Value::Null);
+                let val_b_inner = arr_b.get(i).unwrap_or(&Value::Null);
+                let path = format!("{}/{}", prefix, i);
+                changes.extend(json_diff(&path, val_a_inner, val_b_inner));
+            }
+            changes
+        }
+        _ => {
+            vec![ParamChange {
+                pointer: if prefix.is_empty() {
+                    "/".to_string()
+                } else {
+                    prefix.to_string()
+                },
+                value_a: val_a.clone(),
+                value_b: val_b.clone(),
+            }]
+        }
+    }
+}
+
+/// Diff the tool-call sequences of two runs using LCS alignment.
+pub fn diff_tool_calls_lcs(
+    run_id_a: &str,
+    events_a: &[RunEvent],
+    run_id_b: &str,
+    events_b: &[RunEvent],
+) -> DiffSummary {
+    let calls_a = extract_lcs_tool_calls(events_a);
+    let calls_b = extract_lcs_tool_calls(events_b);
+
+    let alignment = lcs_alignment(&calls_a, &calls_b);
+
+    let mut aligned_a: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let mut aligned_b: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for (i_a, i_b) in &alignment {
+        aligned_a.insert(*i_a);
+        aligned_b.insert(*i_b);
+    }
+
+    let mut changes = Vec::new();
+
+    for (i, call) in calls_a.iter().enumerate() {
+        if !aligned_a.contains(&i) {
+            changes.push(LcsToolCallChange::Removed {
+                entry: call.clone(),
+            });
+        }
+    }
+
+    for (idx, (i_a, i_b)) in alignment.iter().enumerate() {
+        let call_a = &calls_a[*i_a];
+        let call_b = &calls_b[*i_b];
+
+        let is_reordered = if idx > 0 {
+            let (prev_i_a, prev_i_b) = alignment[idx - 1];
+            let prev_call_a = &calls_a[prev_i_a];
+            let prev_call_b = &calls_b[prev_i_b];
+
+            (*i_a > prev_i_a) != (call_a.seq > prev_call_a.seq)
+                || (*i_b > prev_i_b) != (call_b.seq > prev_call_b.seq)
+        } else {
+            false
+        };
+
+        if is_reordered {
+            changes.push(LcsToolCallChange::Reordered {
+                tool_name: call_a.tool_name.clone(),
+                seq_a: call_a.seq,
+                seq_b: call_b.seq,
+            });
+        } else {
+            let param_changes = json_diff("", &call_a.payload, &call_b.payload);
+            if !param_changes.is_empty() {
+                changes.push(LcsToolCallChange::ParamDelta {
+                    tool_name: call_a.tool_name.clone(),
+                    seq_a: call_a.seq,
+                    seq_b: call_b.seq,
+                    changes: param_changes,
+                });
+            }
+        }
+    }
+
+    for (i, call) in calls_b.iter().enumerate() {
+        if !aligned_b.contains(&i) {
+            changes.push(LcsToolCallChange::Added {
+                entry: call.clone(),
+            });
+        }
+    }
+
+    let identical = changes.is_empty();
+
+    DiffSummary {
+        run_id_a: run_id_a.to_string(),
+        run_id_b: run_id_b.to_string(),
+        changes,
+        identical,
+    }
+}
+
+/// Backwards-compatible alias: diff two runs' tool-call sequences.
+pub fn diff_tool_calls(
+    run_id_a: &str,
+    events_a: &[RunEvent],
+    run_id_b: &str,
+    events_b: &[RunEvent],
+) -> DiffSummary {
+    diff_tool_calls_lcs(run_id_a, events_a, run_id_b, events_b)
+}
+
+/// Re-export the original enum name for backwards compatibility with tests.
+pub type ToolCallChange = LcsToolCallChange;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn make_tool_event(seq: u64, tool_name: &str, extra_payload: Option<Value>) -> RunEvent {
+        let mut payload = serde_json::json!({
+            "tool_name": tool_name,
+        });
+        if let Some(extra) = extra_payload {
+            if let Value::Object(ref mut obj) = payload {
+                if let Value::Object(ref extra_obj) = extra {
+                    for (k, v) in extra_obj.iter() {
+                        obj.insert(k.clone(), v.clone());
+                    }
+                }
+            }
+        }
+        RunEvent {
+            seq,
+            kind: "tool_called".to_string(),
+            payload,
+            timestamp: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_identical_runs_no_diff() {
+        let events_a = vec![
+            make_tool_event(1, "search", None),
+            make_tool_event(2, "fetch", None),
+        ];
+        let events_b = vec![
+            make_tool_event(1, "search", None),
+            make_tool_event(2, "fetch", None),
+        ];
+
+        let diff = diff_tool_calls("run_a", &events_a, "run_b", &events_b);
+
+        assert!(diff.identical);
+        assert!(diff.changes.is_empty());
+    }
+
+    #[test]
+    fn test_tool_added() {
+        let events_a = vec![
+            make_tool_event(1, "search", None),
+            make_tool_event(2, "fetch", None),
+        ];
+        let events_b = vec![
+            make_tool_event(1, "search", None),
+            make_tool_event(2, "translate", None),
+            make_tool_event(3, "fetch", None),
+        ];
+
+        let diff = diff_tool_calls("run_a", &events_a, "run_b", &events_b);
+
+        assert!(!diff.identical);
+        assert_eq!(diff.changes.len(), 1);
+
+        match &diff.changes[0] {
+            ToolCallChange::Added { entry } => {
+                assert_eq!(entry.tool_name, "translate");
+            }
+            other => panic!("Expected Added, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_tool_removed() {
+        let events_a = vec![
+            make_tool_event(1, "search", None),
+            make_tool_event(2, "translate", None),
+            make_tool_event(3, "fetch", None),
+        ];
+        let events_b = vec![
+            make_tool_event(1, "search", None),
+            make_tool_event(2, "fetch", None),
+        ];
+
+        let diff = diff_tool_calls("run_a", &events_a, "run_b", &events_b);
+
+        assert!(!diff.identical);
+        assert_eq!(diff.changes.len(), 1);
+
+        match &diff.changes[0] {
+            ToolCallChange::Removed { entry } => {
+                assert_eq!(entry.tool_name, "translate");
+            }
+            other => panic!("Expected Removed, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_param_delta() {
+        let events_a = vec![make_tool_event(
+            1,
+            "search",
+            Some(serde_json::json!({"query": "cats"})),
+        )];
+        let events_b = vec![make_tool_event(
+            1,
+            "search",
+            Some(serde_json::json!({"query": "dogs"})),
+        )];
+
+        let diff = diff_tool_calls("run_a", &events_a, "run_b", &events_b);
+
+        assert!(!diff.identical);
+        assert_eq!(diff.changes.len(), 1);
+
+        match &diff.changes[0] {
+            ToolCallChange::ParamDelta {
+                tool_name, changes, ..
+            } => {
+                assert_eq!(tool_name, "search");
+                assert_eq!(changes.len(), 1);
+                assert_eq!(changes[0].pointer, "/query");
+            }
+            other => panic!("Expected ParamDelta, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_symmetry_property() {
+        let events_a = vec![
+            make_tool_event(1, "search", None),
+            make_tool_event(2, "fetch", None),
+        ];
+        let events_b = vec![
+            make_tool_event(1, "search", None),
+            make_tool_event(2, "translate", None),
+            make_tool_event(3, "fetch", None),
+        ];
+
+        let diff_ab = diff_tool_calls("run_a", &events_a, "run_b", &events_b);
+        let diff_ba = diff_tool_calls("run_b", &events_b, "run_a", &events_a);
+
+        assert!(matches!(&diff_ab.changes[0], ToolCallChange::Added { .. }));
+        assert!(matches!(
+            &diff_ba.changes[0],
+            ToolCallChange::Removed { .. }
+        ));
+    }
+
+    #[test]
+    fn test_empty_vs_nonempty() {
+        let events_a = vec![];
+        let events_b = vec![
+            make_tool_event(1, "search", None),
+            make_tool_event(2, "fetch", None),
+        ];
+
+        let diff = diff_tool_calls("run_a", &events_a, "run_b", &events_b);
+
+        assert!(!diff.identical);
+        assert_eq!(diff.changes.len(), 2);
+
+        for change in &diff.changes {
+            assert!(matches!(change, ToolCallChange::Added { .. }));
+        }
+    }
+}

--- a/crates/aivcs-core/src/lib.rs
+++ b/crates/aivcs-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod parallel;
 pub mod recording;
 pub mod release_registry;
 pub mod replay;
+pub mod reporter;
 pub mod reporting;
 
 pub use diff::lcs_diff::{
@@ -64,6 +65,7 @@ pub use gate::{
 pub use recording::GraphRunRecorder;
 pub use release_registry::ReleaseRegistryApi;
 pub use replay::{replay_run, ReplaySummary};
+pub use reporter::{CaseOutcome, DiffReport, EvalResults};
 pub use reporting::{
     render_diff_summary_md, write_diff_summary_md, write_eval_results_json, DiffSummaryArtifact,
     EvalCaseResultArtifact, EvalResultsArtifact, EvalSummaryArtifact,

--- a/crates/aivcs-core/src/reporter.rs
+++ b/crates/aivcs-core/src/reporter.rs
@@ -1,0 +1,164 @@
+//! PR summary reporter artifacts.
+//!
+//! Provides two output artifacts for CI consumers:
+//! - `EvalResults` — machine-readable per-case eval outcomes + aggregate stats (eval_results.json)
+//! - `DiffReport` — human-readable Markdown comparison of two runs (diff_summary.md)
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::diff::node_paths::NodePathDiff;
+use crate::diff::state_diff::ScopedStateDiff;
+use crate::diff::tool_calls::{ToolCallChange, ToolCallDiff};
+use crate::domain::eval::EvalSuite;
+
+// ── eval_results.json schema ──────────────────────────────────────────────
+
+/// Outcome of a single eval test case.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CaseOutcome {
+    pub case_id: Uuid,
+    pub tags: Vec<String>,
+    pub passed: bool,
+    pub score: f32,
+    pub reason: Option<String>,
+}
+
+/// Aggregate evaluation results for an entire suite run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EvalResults {
+    pub suite_id: Uuid,
+    pub suite_name: String,
+    pub suite_version: String,
+    pub run_at: DateTime<Utc>,
+    pub outcomes: Vec<CaseOutcome>,
+    pub total: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub pass_rate: f32,
+}
+
+impl EvalResults {
+    /// Build `EvalResults` from a suite and a vec of per-case outcomes.
+    pub fn new(suite: &EvalSuite, outcomes: Vec<CaseOutcome>) -> Self {
+        let total = outcomes.len();
+        let passed = outcomes.iter().filter(|o| o.passed).count();
+        let failed = total - passed;
+        let pass_rate = if total == 0 {
+            0.0
+        } else {
+            passed as f32 / total as f32
+        };
+
+        Self {
+            suite_id: suite.suite_id,
+            suite_name: suite.name.clone(),
+            suite_version: suite.version.clone(),
+            run_at: Utc::now(),
+            outcomes,
+            total,
+            passed,
+            failed,
+            pass_rate,
+        }
+    }
+}
+
+// ── diff_summary.md rendering ─────────────────────────────────────────────
+
+/// A diff report comparing two runs across tool calls, node paths, and state.
+pub struct DiffReport<'a> {
+    pub run_id_a: &'a str,
+    pub run_id_b: &'a str,
+    pub tool_call_diff: Option<&'a ToolCallDiff>,
+    pub node_path_diff: Option<&'a NodePathDiff>,
+    pub state_diff: Option<&'a ScopedStateDiff>,
+}
+
+impl<'a> DiffReport<'a> {
+    /// Render the diff report as a Markdown string.
+    pub fn render_markdown(&self) -> String {
+        let mut md = format!("# Diff Summary: {} vs {}\n", self.run_id_a, self.run_id_b);
+
+        // Tool Calls section
+        md.push_str("\n## Tool Calls\n\n");
+        match self.tool_call_diff {
+            Some(diff) if !diff.is_empty() => {
+                for change in &diff.changes {
+                    match change {
+                        ToolCallChange::Added(call) => {
+                            md.push_str(&format!("- **Added**: `{}`\n", call.tool_name));
+                        }
+                        ToolCallChange::Removed(call) => {
+                            md.push_str(&format!("- **Removed**: `{}`\n", call.tool_name));
+                        }
+                        ToolCallChange::Reordered {
+                            call,
+                            from_index,
+                            to_index,
+                        } => {
+                            md.push_str(&format!(
+                                "- **Reordered**: `{}` (index {} → {})\n",
+                                call.tool_name, from_index, to_index
+                            ));
+                        }
+                        ToolCallChange::ParamChanged {
+                            tool_name, deltas, ..
+                        } => {
+                            md.push_str(&format!(
+                                "- **ParamChanged**: `{}` ({} delta(s))\n",
+                                tool_name,
+                                deltas.len()
+                            ));
+                        }
+                    }
+                }
+            }
+            _ => {
+                md.push_str("identical\n");
+            }
+        }
+
+        // Node Path section
+        md.push_str("\n## Node Path\n\n");
+        match self.node_path_diff {
+            Some(diff) if !diff.is_empty() => {
+                if let Some(ref div) = diff.divergence {
+                    md.push_str(&format!(
+                        "- Common prefix: [{}]\n",
+                        div.common_prefix.join(", ")
+                    ));
+                    let tail_a_ids: Vec<&str> =
+                        div.tail_a.iter().map(|s| s.node_id.as_str()).collect();
+                    let tail_b_ids: Vec<&str> =
+                        div.tail_b.iter().map(|s| s.node_id.as_str()).collect();
+                    md.push_str(&format!("- tail_a: [{}]\n", tail_a_ids.join(", ")));
+                    md.push_str(&format!("- tail_b: [{}]\n", tail_b_ids.join(", ")));
+                }
+            }
+            _ => {
+                md.push_str("identical\n");
+            }
+        }
+
+        // State section
+        md.push_str("\n## State\n\n");
+        match self.state_diff {
+            Some(diff) if !diff.is_empty() => {
+                md.push_str(&format!("{} delta(s):\n", diff.deltas.len()));
+                for delta in &diff.deltas {
+                    md.push_str(&format!(
+                        "- `{}`: {} → {}\n",
+                        delta.pointer, delta.before, delta.after
+                    ));
+                }
+            }
+            _ => {
+                md.push_str("identical\n");
+            }
+        }
+
+        md
+    }
+}

--- a/crates/aivcs-core/tests/reporter.rs
+++ b/crates/aivcs-core/tests/reporter.rs
@@ -1,0 +1,220 @@
+use aivcs_core::diff::node_paths::{NodeDivergence, NodePathDiff, NodeStep};
+use aivcs_core::diff::state_diff::{ScopedStateDiff, StateDelta};
+use aivcs_core::diff::tool_calls::{ToolCall, ToolCallChange, ToolCallDiff};
+use aivcs_core::{CaseOutcome, DiffReport, EvalResults, EvalSuite};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+fn sample_suite() -> EvalSuite {
+    EvalSuite::new("my-suite".to_string(), "1.0.0".to_string())
+}
+
+fn case_outcome(passed: bool, score: f32) -> CaseOutcome {
+    CaseOutcome {
+        case_id: Uuid::new_v4(),
+        tags: vec!["smoke".to_string()],
+        passed,
+        score,
+        reason: if passed {
+            None
+        } else {
+            Some("mismatch".to_string())
+        },
+    }
+}
+
+// ── EvalResults tests ─────────────────────────────────────────────────────
+
+#[test]
+fn eval_results_serde_roundtrip() {
+    let suite = sample_suite();
+    let outcomes = vec![case_outcome(true, 1.0), case_outcome(false, 0.3)];
+    let results = EvalResults::new(&suite, outcomes);
+
+    let json_str = serde_json::to_string(&results).expect("serialize");
+    let deserialized: EvalResults = serde_json::from_str(&json_str).expect("deserialize");
+
+    assert_eq!(results, deserialized);
+}
+
+#[test]
+fn eval_results_schema_fields_in_json() {
+    let suite = sample_suite();
+    let results = EvalResults::new(&suite, vec![case_outcome(true, 1.0)]);
+
+    let v: Value = serde_json::to_value(&results).expect("to_value");
+    let obj = v.as_object().expect("top-level object");
+
+    for key in &[
+        "suite_id",
+        "suite_name",
+        "suite_version",
+        "run_at",
+        "outcomes",
+        "total",
+        "passed",
+        "failed",
+        "pass_rate",
+    ] {
+        assert!(obj.contains_key(*key), "missing key: {}", key);
+    }
+}
+
+#[test]
+fn eval_results_pass_rate_all_pass() {
+    let suite = sample_suite();
+    let outcomes = vec![
+        case_outcome(true, 1.0),
+        case_outcome(true, 0.9),
+        case_outcome(true, 1.0),
+    ];
+    let results = EvalResults::new(&suite, outcomes);
+
+    assert_eq!(results.total, 3);
+    assert_eq!(results.passed, 3);
+    assert_eq!(results.failed, 0);
+    assert!((results.pass_rate - 1.0).abs() < f32::EPSILON);
+}
+
+#[test]
+fn eval_results_pass_rate_mixed() {
+    let suite = sample_suite();
+    let outcomes = vec![
+        case_outcome(true, 1.0),
+        case_outcome(false, 0.2),
+        case_outcome(true, 0.8),
+        case_outcome(false, 0.1),
+    ];
+    let results = EvalResults::new(&suite, outcomes);
+
+    assert_eq!(results.total, 4);
+    assert_eq!(results.passed, 2);
+    assert_eq!(results.failed, 2);
+    assert!((results.pass_rate - 0.5).abs() < f32::EPSILON);
+}
+
+#[test]
+fn eval_results_empty_outcomes_zero_pass_rate() {
+    let suite = sample_suite();
+    let results = EvalResults::new(&suite, vec![]);
+
+    assert_eq!(results.total, 0);
+    assert_eq!(results.passed, 0);
+    assert_eq!(results.failed, 0);
+    assert!((results.pass_rate - 0.0).abs() < f32::EPSILON);
+}
+
+// ── DiffReport tests ─────────────────────────────────────────────────────
+
+#[test]
+fn diff_report_render_identical_runs() {
+    let report = DiffReport {
+        run_id_a: "run-A",
+        run_id_b: "run-B",
+        tool_call_diff: None,
+        node_path_diff: None,
+        state_diff: None,
+    };
+    let md = report.render_markdown();
+
+    assert!(md.contains("# Diff Summary: run-A vs run-B"));
+    assert!(md.contains("## Tool Calls"));
+    assert!(md.contains("## Node Path"));
+    assert!(md.contains("## State"));
+    // All sections should say identical
+    let identical_count = md.matches("identical").count();
+    assert_eq!(identical_count, 3, "all 3 sections should say identical");
+}
+
+#[test]
+fn diff_report_render_tool_call_added() {
+    let diff = ToolCallDiff {
+        changes: vec![ToolCallChange::Added(ToolCall {
+            seq: 1,
+            tool_name: "new_tool".to_string(),
+            params: json!({}),
+        })],
+    };
+    let report = DiffReport {
+        run_id_a: "a",
+        run_id_b: "b",
+        tool_call_diff: Some(&diff),
+        node_path_diff: None,
+        state_diff: None,
+    };
+    let md = report.render_markdown();
+
+    assert!(md.contains("**Added**: `new_tool`"));
+}
+
+#[test]
+fn diff_report_render_tool_call_removed() {
+    let diff = ToolCallDiff {
+        changes: vec![ToolCallChange::Removed(ToolCall {
+            seq: 2,
+            tool_name: "old_tool".to_string(),
+            params: json!({}),
+        })],
+    };
+    let report = DiffReport {
+        run_id_a: "a",
+        run_id_b: "b",
+        tool_call_diff: Some(&diff),
+        node_path_diff: None,
+        state_diff: None,
+    };
+    let md = report.render_markdown();
+
+    assert!(md.contains("**Removed**: `old_tool`"));
+}
+
+#[test]
+fn diff_report_render_node_divergence() {
+    let diff = NodePathDiff {
+        divergence: Some(NodeDivergence {
+            common_prefix: vec!["start".to_string(), "middle".to_string()],
+            tail_a: vec![NodeStep {
+                seq: 3,
+                node_id: "left".to_string(),
+            }],
+            tail_b: vec![NodeStep {
+                seq: 3,
+                node_id: "right".to_string(),
+            }],
+        }),
+    };
+    let report = DiffReport {
+        run_id_a: "a",
+        run_id_b: "b",
+        tool_call_diff: None,
+        node_path_diff: Some(&diff),
+        state_diff: None,
+    };
+    let md = report.render_markdown();
+
+    assert!(md.contains("Common prefix: [start, middle]"));
+    assert!(md.contains("tail_a: [left]"));
+    assert!(md.contains("tail_b: [right]"));
+}
+
+#[test]
+fn diff_report_render_state_delta() {
+    let diff = ScopedStateDiff {
+        deltas: vec![StateDelta {
+            pointer: "/config/retries".to_string(),
+            before: json!(3),
+            after: json!(5),
+        }],
+    };
+    let report = DiffReport {
+        run_id_a: "a",
+        run_id_b: "b",
+        tool_call_diff: None,
+        node_path_diff: None,
+        state_diff: Some(&diff),
+    };
+    let md = report.render_markdown();
+
+    assert!(md.contains("1 delta(s)"));
+    assert!(md.contains("`/config/retries`: 3 → 5"));
+}

--- a/crates/aivcs-core/tests/tool_call_diff.rs
+++ b/crates/aivcs-core/tests/tool_call_diff.rs
@@ -1,4 +1,4 @@
-use aivcs_core::{diff_tool_calls, ToolCallChange};
+use aivcs_core::diff::tool_calls::{diff_tool_calls, ToolCallChange};
 use chrono::Utc;
 use oxidized_state::RunEvent;
 use serde_json::json;


### PR DESCRIPTION
## Summary

- Adds `CaseOutcome` + `EvalResults` types for machine-readable eval results (`eval_results.json` schema) with serde support and aggregate pass/fail/pass_rate stats
- Adds `DiffReport` struct with `render_markdown()` producing a human-readable diff summary covering tool calls, node paths, and state deltas
- Introduces `ScopedStateDiff` + `StateDelta` types in new `diff::state_diff` submodule
- Resolves pre-existing `diff.rs` / `diff/mod.rs` dual-module conflict (E0761) by consolidating LCS-based diff into `diff/mod.rs`

## Test plan

- [x] 10 new integration tests in `tests/reporter.rs`:
  - Serde roundtrip, JSON schema field presence
  - Pass rate: all-pass, mixed, empty (zero division)
  - DiffReport: identical runs, tool added/removed, node divergence, state delta
- [x] All 123 existing tests pass (`cargo test -p aivcs-core`)
- [x] `cargo clippy -p aivcs-core --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)