### PR TITLE
feat: compatibility validator for promotes (M4-PR2)

### DIFF
--- a/crates/aivcs-core/src/compat.rs
+++ b/crates/aivcs-core/src/compat.rs
@@ -1,0 +1,171 @@
+//! Compatibility validator for release promotions.
+//!
+//! Evaluates a candidate [`Release`] against a [`CompatRuleSet`] to produce a
+//! [`CompatVerdict`] — the pass/fail decision that blocks or allows a promote.
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::release::Release;
+
+/// A single compatibility rule that can block a promotion.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CompatRule {
+    /// Candidate `spec_digest` must be a valid 64-char lowercase hex string.
+    SpecDigestValid,
+    /// `tools_digest` must be non-empty.
+    RequireToolsDigest,
+    /// `graph_digest` must be non-empty.
+    RequireGraphDigest,
+    /// `tools_digest` must not change vs. the current release (if one exists).
+    NoToolsChange,
+    /// `graph_digest` must not change vs. the current release (if one exists).
+    NoGraphChange,
+}
+
+/// A set of compatibility rules to evaluate before promoting.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CompatRuleSet {
+    pub rules: Vec<CompatRule>,
+}
+
+impl CompatRuleSet {
+    /// Standard rule set: `SpecDigestValid` + `RequireToolsDigest` + `RequireGraphDigest`.
+    pub fn standard() -> Self {
+        Self {
+            rules: vec![
+                CompatRule::SpecDigestValid,
+                CompatRule::RequireToolsDigest,
+                CompatRule::RequireGraphDigest,
+            ],
+        }
+    }
+
+    /// Add a rule to this set (builder pattern).
+    pub fn with_rule(mut self, rule: CompatRule) -> Self {
+        self.rules.push(rule);
+        self
+    }
+}
+
+/// Context for evaluating compatibility of a candidate release.
+pub struct PromoteContext<'a> {
+    /// The candidate release to validate.
+    pub candidate: &'a Release,
+    /// The existing release at the target environment (if any).
+    pub current: Option<&'a Release>,
+}
+
+/// A single rule violation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CompatViolation {
+    /// Which rule was violated.
+    pub rule: CompatRule,
+    /// Human-readable explanation.
+    pub reason: String,
+}
+
+/// The outcome of evaluating a compat rule set against a promote context.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CompatVerdict {
+    /// Violations found (empty when passed).
+    pub violations: Vec<CompatViolation>,
+}
+
+impl CompatVerdict {
+    /// Whether the verdict passed (no violations).
+    pub fn passed(&self) -> bool {
+        self.violations.is_empty()
+    }
+}
+
+/// Evaluate a [`PromoteContext`] against a [`CompatRuleSet`], returning a [`CompatVerdict`].
+pub fn evaluate_compat(rule_set: &CompatRuleSet, ctx: &PromoteContext) -> CompatVerdict {
+    let mut violations = Vec::new();
+
+    for rule in &rule_set.rules {
+        if let Some(v) = check_rule(rule, ctx) {
+            violations.push(v);
+        }
+    }
+
+    CompatVerdict { violations }
+}
+
+fn is_valid_hex_digest(s: &str) -> bool {
+    s.len() == 64
+        && s.chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
+
+fn check_rule(rule: &CompatRule, ctx: &PromoteContext) -> Option<CompatViolation> {
+    match rule {
+        CompatRule::SpecDigestValid => {
+            if !is_valid_hex_digest(&ctx.candidate.spec_digest) {
+                Some(CompatViolation {
+                    rule: rule.clone(),
+                    reason: format!(
+                        "spec_digest '{}' is not a valid 64-char lowercase hex string",
+                        ctx.candidate.spec_digest,
+                    ),
+                })
+            } else {
+                None
+            }
+        }
+        CompatRule::RequireToolsDigest => {
+            if ctx.candidate.tools_digest.is_empty() {
+                Some(CompatViolation {
+                    rule: rule.clone(),
+                    reason: "tools_digest is empty".to_string(),
+                })
+            } else {
+                None
+            }
+        }
+        CompatRule::RequireGraphDigest => {
+            if ctx.candidate.graph_digest.is_empty() {
+                Some(CompatViolation {
+                    rule: rule.clone(),
+                    reason: "graph_digest is empty".to_string(),
+                })
+            } else {
+                None
+            }
+        }
+        CompatRule::NoToolsChange => {
+            if let Some(current) = ctx.current {
+                if ctx.candidate.tools_digest != current.tools_digest {
+                    Some(CompatViolation {
+                        rule: rule.clone(),
+                        reason: format!(
+                            "tools_digest changed: '{}' -> '{}'",
+                            current.tools_digest, ctx.candidate.tools_digest,
+                        ),
+                    })
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }
+        CompatRule::NoGraphChange => {
+            if let Some(current) = ctx.current {
+                if ctx.candidate.graph_digest != current.graph_digest {
+                    Some(CompatViolation {
+                        rule: rule.clone(),
+                        reason: format!(
+                            "graph_digest changed: '{}' -> '{}'",
+                            current.graph_digest, ctx.candidate.graph_digest,
+                        ),
+                    })
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }
+    }
+}

--- a/crates/aivcs-core/src/domain/release.rs
+++ b/crates/aivcs-core/src/domain/release.rs
@@ -25,6 +25,12 @@ pub struct Release {
     /// Digest of the AgentSpec being released.
     pub spec_digest: String,
 
+    /// Digest of the tools configuration.
+    pub tools_digest: String,
+
+    /// Digest of the graph definition.
+    pub graph_digest: String,
+
     /// Semantic version of the release.
     pub version: String,
 
@@ -46,6 +52,8 @@ impl Release {
     pub fn new(
         agent_name: String,
         spec_digest: String,
+        tools_digest: String,
+        graph_digest: String,
         version: String,
         environment: ReleaseEnvironment,
         promoted_by: String,
@@ -54,6 +62,8 @@ impl Release {
             release_id: Uuid::new_v4(),
             agent_name,
             spec_digest,
+            tools_digest,
+            graph_digest,
             version,
             environment,
             promoted_at: Utc::now(),
@@ -107,6 +117,8 @@ mod tests {
         let release = Release::new(
             "my_agent".to_string(),
             "spec_digest_123".to_string(),
+            "tools_digest_abc".to_string(),
+            "graph_digest_xyz".to_string(),
             "1.2.3".to_string(),
             ReleaseEnvironment::Production,
             "github-ci".to_string(),

--- a/crates/aivcs-core/src/lib.rs
+++ b/crates/aivcs-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! Re-exports core components for programmatic access to AIVCS functionality.
 
 pub mod cas;
+pub mod compat;
 pub mod diff;
 pub mod domain;
 pub mod event_adapter;
@@ -50,6 +51,9 @@ pub use parallel::{
     fork_agent_parallel, BranchStatus, ForkResult, ParallelConfig, ParallelManager,
 };
 
+pub use compat::{
+    evaluate_compat, CompatRule, CompatRuleSet, CompatVerdict, CompatViolation, PromoteContext,
+};
 pub use diff::node_paths::{
     diff_node_paths, extract_node_path, NodeDivergence, NodePathDiff, NodeStep,
 };

--- a/crates/aivcs-core/tests/compat.rs
+++ b/crates/aivcs-core/tests/compat.rs
@@ -1,0 +1,209 @@
+use aivcs_core::domain::release::{Release, ReleaseEnvironment};
+use aivcs_core::{
+    evaluate_compat, CompatRule, CompatRuleSet, CompatVerdict, CompatViolation, PromoteContext,
+};
+
+/// Valid 64-char lowercase hex digest for tests.
+const VALID_DIGEST: &str = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+const VALID_TOOLS: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+const VALID_GRAPH: &str = "2222222222222222222222222222222222222222222222222222222222222222";
+
+fn make_release(spec: &str, tools: &str, graph: &str) -> Release {
+    Release::new(
+        "test-agent".to_string(),
+        spec.to_string(),
+        tools.to_string(),
+        graph.to_string(),
+        "1.0.0".to_string(),
+        ReleaseEnvironment::Staging,
+        "ci".to_string(),
+    )
+}
+
+// ── SpecDigestValid ─────────────────────────────────────────────────────
+
+#[test]
+fn spec_digest_valid_passes_well_formed() {
+    let candidate = make_release(VALID_DIGEST, VALID_TOOLS, VALID_GRAPH);
+    let ctx = PromoteContext {
+        candidate: &candidate,
+        current: None,
+    };
+    let rules = CompatRuleSet {
+        rules: vec![CompatRule::SpecDigestValid],
+    };
+    let verdict = evaluate_compat(&rules, &ctx);
+    assert!(verdict.passed());
+}
+
+#[test]
+fn spec_digest_valid_fails_empty() {
+    let candidate = make_release("", VALID_TOOLS, VALID_GRAPH);
+    let ctx = PromoteContext {
+        candidate: &candidate,
+        current: None,
+    };
+    let rules = CompatRuleSet {
+        rules: vec![CompatRule::SpecDigestValid],
+    };
+    let verdict = evaluate_compat(&rules, &ctx);
+    assert!(!verdict.passed());
+    assert_eq!(verdict.violations.len(), 1);
+    assert_eq!(verdict.violations[0].rule, CompatRule::SpecDigestValid);
+}
+
+#[test]
+fn spec_digest_valid_fails_wrong_length() {
+    let candidate = make_release("abcdef", VALID_TOOLS, VALID_GRAPH);
+    let ctx = PromoteContext {
+        candidate: &candidate,
+        current: None,
+    };
+    let rules = CompatRuleSet {
+        rules: vec![CompatRule::SpecDigestValid],
+    };
+    let verdict = evaluate_compat(&rules, &ctx);
+    assert!(!verdict.passed());
+}
+
+#[test]
+fn spec_digest_valid_fails_non_hex() {
+    // 64 chars but contains 'g' which is not hex
+    let bad = "gggggggg0123456789abcdef0123456789abcdef0123456789abcdef01234567";
+    assert_eq!(bad.len(), 64);
+    let candidate = make_release(bad, VALID_TOOLS, VALID_GRAPH);
+    let ctx = PromoteContext {
+        candidate: &candidate,
+        current: None,
+    };
+    let rules = CompatRuleSet {
+        rules: vec![CompatRule::SpecDigestValid],
+    };
+    let verdict = evaluate_compat(&rules, &ctx);
+    assert!(!verdict.passed());
+}
+
+// ── RequireToolsDigest / RequireGraphDigest ──────────────────────────────
+
+#[test]
+fn require_tools_digest_fails_empty() {
+    let candidate = make_release(VALID_DIGEST, "", VALID_GRAPH);
+    let ctx = PromoteContext {
+        candidate: &candidate,
+        current: None,
+    };
+    let rules = CompatRuleSet {
+        rules: vec![CompatRule::RequireToolsDigest],
+    };
+    let verdict = evaluate_compat(&rules, &ctx);
+    assert!(!verdict.passed());
+    assert_eq!(verdict.violations[0].rule, CompatRule::RequireToolsDigest);
+}
+
+#[test]
+fn require_graph_digest_fails_empty() {
+    let candidate = make_release(VALID_DIGEST, VALID_TOOLS, "");
+    let ctx = PromoteContext {
+        candidate: &candidate,
+        current: None,
+    };
+    let rules = CompatRuleSet {
+        rules: vec![CompatRule::RequireGraphDigest],
+    };
+    let verdict = evaluate_compat(&rules, &ctx);
+    assert!(!verdict.passed());
+    assert_eq!(verdict.violations[0].rule, CompatRule::RequireGraphDigest);
+}
+
+// ── NoToolsChange / NoGraphChange ───────────────────────────────────────
+
+#[test]
+fn no_tools_change_passes_same_digest() {
+    let candidate = make_release(VALID_DIGEST, VALID_TOOLS, VALID_GRAPH);
+    let current = make_release(VALID_DIGEST, VALID_TOOLS, VALID_GRAPH);
+    let ctx = PromoteContext {
+        candidate: &candidate,
+        current: Some(&current),
+    };
+    let rules = CompatRuleSet {
+        rules: vec![CompatRule::NoToolsChange],
+    };
+    let verdict = evaluate_compat(&rules, &ctx);
+    assert!(verdict.passed());
+}
+
+#[test]
+fn no_tools_change_fails_different_digest() {
+    let other_tools = "3333333333333333333333333333333333333333333333333333333333333333";
+    let candidate = make_release(VALID_DIGEST, other_tools, VALID_GRAPH);
+    let current = make_release(VALID_DIGEST, VALID_TOOLS, VALID_GRAPH);
+    let ctx = PromoteContext {
+        candidate: &candidate,
+        current: Some(&current),
+    };
+    let rules = CompatRuleSet {
+        rules: vec![CompatRule::NoToolsChange],
+    };
+    let verdict = evaluate_compat(&rules, &ctx);
+    assert!(!verdict.passed());
+    assert_eq!(verdict.violations[0].rule, CompatRule::NoToolsChange);
+}
+
+#[test]
+fn no_graph_change_fails_different_digest() {
+    let other_graph = "4444444444444444444444444444444444444444444444444444444444444444";
+    let candidate = make_release(VALID_DIGEST, VALID_TOOLS, other_graph);
+    let current = make_release(VALID_DIGEST, VALID_TOOLS, VALID_GRAPH);
+    let ctx = PromoteContext {
+        candidate: &candidate,
+        current: Some(&current),
+    };
+    let rules = CompatRuleSet {
+        rules: vec![CompatRule::NoGraphChange],
+    };
+    let verdict = evaluate_compat(&rules, &ctx);
+    assert!(!verdict.passed());
+    assert_eq!(verdict.violations[0].rule, CompatRule::NoGraphChange);
+}
+
+#[test]
+fn no_tools_change_passes_when_no_current_release() {
+    let candidate = make_release(VALID_DIGEST, VALID_TOOLS, VALID_GRAPH);
+    let ctx = PromoteContext {
+        candidate: &candidate,
+        current: None,
+    };
+    let rules = CompatRuleSet {
+        rules: vec![CompatRule::NoToolsChange, CompatRule::NoGraphChange],
+    };
+    let verdict = evaluate_compat(&rules, &ctx);
+    assert!(verdict.passed());
+}
+
+// ── Edge cases ──────────────────────────────────────────────────────────
+
+#[test]
+fn empty_rules_always_passes() {
+    let candidate = make_release("", "", "");
+    let ctx = PromoteContext {
+        candidate: &candidate,
+        current: None,
+    };
+    let rules = CompatRuleSet { rules: vec![] };
+    let verdict = evaluate_compat(&rules, &ctx);
+    assert!(verdict.passed());
+    assert!(verdict.violations.is_empty());
+}
+
+#[test]
+fn compat_verdict_serde_roundtrip() {
+    let verdict = CompatVerdict {
+        violations: vec![CompatViolation {
+            rule: CompatRule::SpecDigestValid,
+            reason: "bad digest".to_string(),
+        }],
+    };
+    let json = serde_json::to_string(&verdict).expect("serialize");
+    let deserialized: CompatVerdict = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(verdict, deserialized);
+}


### PR DESCRIPTION
## Summary
- Add `CompatRuleSet` / `CompatVerdict` engine that validates candidate `Release` objects before promotion
- Support rules: `SpecDigestValid`, `RequireToolsDigest`, `RequireGraphDigest`, `NoToolsChange`, `NoGraphChange`
- Extend `Release` struct with `tools_digest` and `graph_digest` fields
- Mirror the existing gate module pattern (`GateRuleSet` / `GateVerdict` / `evaluate_gate`)

## Test plan
- [x] 12 integration tests in `tests/compat.rs` covering all rules and edge cases
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — all 284 tests pass

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)