### PR TITLE
feat(release): M4-PR2 compatibility validator for promotes

### DIFF
--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -17,7 +17,7 @@ use nix_env_manager::{
     AtticClient, NixHash,
 };
 use oxidized_state::{
-    BranchRecord, CommitId, CommitRecord, ContentDigest, ReleaseRegistry, RunEvent, RunLedger,
+    BranchRecord, CommitId, CommitRecord, ReleaseRegistry, RunEvent, RunLedger,
     SurrealDbReleaseRegistry, SurrealHandle, SurrealRunLedger,
 };
 use serde::Serialize;
@@ -270,12 +270,25 @@ enum DiffAction {
 
 #[derive(Subcommand)]
 enum ReleaseAction {
-    /// Promote a spec digest as the latest release for an agent
+    /// Promote a validated agent spec as the latest release
     Promote {
         /// Agent name
         name: String,
-        /// 64-char hex content digest
-        digest: String,
+        /// Git commit SHA linked to this spec
+        #[arg(long)]
+        git_sha: String,
+        /// SHA256 hex of graph definition
+        #[arg(long)]
+        graph_digest: String,
+        /// SHA256 hex of prompts definition
+        #[arg(long)]
+        prompts_digest: String,
+        /// SHA256 hex of tools definition
+        #[arg(long)]
+        tools_digest: String,
+        /// SHA256 hex of configuration
+        #[arg(long)]
+        config_digest: String,
         /// Who promoted this release
         #[arg(long, default_value = "aivcs-cli")]
         promoted_by: String,
@@ -376,7 +389,11 @@ async fn main() -> Result<()> {
         Commands::Release { action } => match action {
             ReleaseAction::Promote {
                 name,
-                digest,
+                git_sha,
+                graph_digest,
+                prompts_digest,
+                tools_digest,
+                config_digest,
                 promoted_by,
                 version,
                 notes,
@@ -384,7 +401,11 @@ async fn main() -> Result<()> {
                 cmd_release_promote(
                     &handle,
                     &name,
-                    &digest,
+                    &git_sha,
+                    &graph_digest,
+                    &prompts_digest,
+                    &tools_digest,
+                    &config_digest,
                     &promoted_by,
                     version.as_deref(),
                     notes.as_deref(),
@@ -1070,25 +1091,42 @@ async fn cmd_env_info() -> Result<()> {
 
 // ========== Release Registry Commands (Phase 4) ==========
 
+#[allow(clippy::too_many_arguments)]
 async fn cmd_release_promote(
     handle: &SurrealHandle,
     name: &str,
-    digest: &str,
+    git_sha: &str,
+    graph_digest: &str,
+    prompts_digest: &str,
+    tools_digest: &str,
+    config_digest: &str,
     promoted_by: &str,
     version: Option<&str>,
     notes: Option<&str>,
 ) -> Result<()> {
+    let spec = aivcs_core::AgentSpec::new(
+        git_sha.to_string(),
+        graph_digest.to_string(),
+        prompts_digest.to_string(),
+        tools_digest.to_string(),
+        config_digest.to_string(),
+    )
+    .context("failed to build AgentSpec")?;
+
     let registry = SurrealDbReleaseRegistry::new(Arc::new(handle.clone()));
-    let parsed_digest = ContentDigest::try_from(digest.to_string())
-        .context("invalid digest (expected 64-char hex)")?;
+    let api = aivcs_core::ReleaseRegistryApi::new(registry);
 
-    let metadata = oxidized_state::ReleaseMetadata {
-        version_label: version.map(ToString::to_string),
-        promoted_by: promoted_by.to_string(),
-        notes: notes.map(ToString::to_string),
-    };
+    let release = api
+        .promote(
+            name,
+            &spec,
+            promoted_by,
+            version.map(ToString::to_string),
+            notes.map(ToString::to_string),
+        )
+        .await
+        .context("promote failed")?;
 
-    let release = registry.promote(name, &parsed_digest, metadata).await?;
     println!(
         "Promoted {} -> {}",
         release.name,

--- a/crates/aivcs-core/src/release_registry.rs
+++ b/crates/aivcs-core/src/release_registry.rs
@@ -1,6 +1,46 @@
+use crate::domain::agent_spec::AgentSpec;
+use crate::domain::error::{AivcsError, Result};
 use oxidized_state::{
     ContentDigest, ReleaseMetadata, ReleaseRecord, ReleaseRegistry, StorageResult,
 };
+
+/// Validate an `AgentSpec` for promotion, returning the derived `ContentDigest`.
+///
+/// Checks (in order):
+/// 1. All component digests are non-empty.
+/// 2. `git_sha` is non-empty.
+/// 3. `spec_digest` matches the recomputed digest over components.
+/// 4. `spec_digest` is valid 64-char lowercase hex.
+fn validate_spec_for_promote(spec: &AgentSpec) -> Result<ContentDigest> {
+    if spec.graph_digest.is_empty() {
+        return Err(AivcsError::InvalidAgentSpec(
+            "graph_digest is empty".to_string(),
+        ));
+    }
+    if spec.prompts_digest.is_empty() {
+        return Err(AivcsError::InvalidAgentSpec(
+            "prompts_digest is empty".to_string(),
+        ));
+    }
+    if spec.tools_digest.is_empty() {
+        return Err(AivcsError::InvalidAgentSpec(
+            "tools_digest is empty".to_string(),
+        ));
+    }
+    if spec.config_digest.is_empty() {
+        return Err(AivcsError::InvalidAgentSpec(
+            "config_digest is empty".to_string(),
+        ));
+    }
+    if spec.git_sha.is_empty() {
+        return Err(AivcsError::InvalidAgentSpec("git_sha is empty".to_string()));
+    }
+
+    spec.verify_digest()?;
+
+    ContentDigest::try_from(spec.spec_digest.clone())
+        .map_err(|e| AivcsError::InvalidAgentSpec(format!("spec_digest is not valid hex: {}", e)))
+}
 
 /// Thin API layer over a release registry backend.
 pub struct ReleaseRegistryApi<R> {
@@ -18,17 +58,22 @@ where
     pub async fn promote(
         &self,
         name: &str,
-        spec_digest: &ContentDigest,
+        spec: &AgentSpec,
         promoted_by: &str,
         version_label: Option<String>,
         notes: Option<String>,
-    ) -> StorageResult<ReleaseRecord> {
+    ) -> Result<ReleaseRecord> {
+        let content_digest = validate_spec_for_promote(spec)?;
+
         let metadata = ReleaseMetadata {
             version_label,
             promoted_by: promoted_by.to_string(),
             notes,
         };
-        self.registry.promote(name, spec_digest, metadata).await
+        self.registry
+            .promote(name, &content_digest, metadata)
+            .await
+            .map_err(|e| AivcsError::StorageError(e.to_string()))
     }
 
     pub async fn rollback(&self, name: &str) -> StorageResult<ReleaseRecord> {
@@ -46,55 +91,66 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::ReleaseRegistryApi;
+    use super::*;
+    use crate::domain::agent_spec::AgentSpec;
     use oxidized_state::fakes::MemoryReleaseRegistry;
-    use oxidized_state::ContentDigest;
+
+    fn make_spec(seed: &str) -> AgentSpec {
+        AgentSpec::new(
+            "abc123def456abc123def456abc123def456abc1".to_string(),
+            format!("graph-{}", seed),
+            format!("prompts-{}", seed),
+            format!("tools-{}", seed),
+            format!("config-{}", seed),
+        )
+        .expect("make_spec")
+    }
 
     #[tokio::test]
     async fn promote_promote_rollback_keeps_append_only_history() {
         let api = ReleaseRegistryApi::new(MemoryReleaseRegistry::new());
         let name = "agent-registry";
-        let d1 = ContentDigest::from_bytes(b"spec-v1");
-        let d2 = ContentDigest::from_bytes(b"spec-v2");
+        let spec1 = make_spec("v1");
+        let spec2 = make_spec("v2");
 
         let first = api
             .promote(
                 name,
-                &d1,
+                &spec1,
                 "ci",
                 Some("v1.0.0".to_string()),
                 Some("first release".to_string()),
             )
             .await
             .expect("first promote");
-        assert_eq!(first.spec_digest, d1);
+        assert_eq!(first.spec_digest.as_str(), spec1.spec_digest);
 
         let second = api
             .promote(
                 name,
-                &d2,
+                &spec2,
                 "ci",
                 Some("v1.1.0".to_string()),
                 Some("second release".to_string()),
             )
             .await
             .expect("second promote");
-        assert_eq!(second.spec_digest, d2);
+        assert_eq!(second.spec_digest.as_str(), spec2.spec_digest);
 
         let rolled_back = api.rollback(name).await.expect("rollback");
-        assert_eq!(rolled_back.spec_digest, d1);
+        assert_eq!(rolled_back.spec_digest.as_str(), spec1.spec_digest);
 
         let current = api
             .current(name)
             .await
             .expect("current")
             .expect("current exists");
-        assert_eq!(current.spec_digest, d1);
+        assert_eq!(current.spec_digest.as_str(), spec1.spec_digest);
 
         let history = api.history(name).await.expect("history");
         assert_eq!(history.len(), 3);
-        assert_eq!(history[0].spec_digest, d1);
-        assert_eq!(history[1].spec_digest, d2);
-        assert_eq!(history[2].spec_digest, d1);
+        assert_eq!(history[0].spec_digest.as_str(), spec1.spec_digest);
+        assert_eq!(history[1].spec_digest.as_str(), spec2.spec_digest);
+        assert_eq!(history[2].spec_digest.as_str(), spec1.spec_digest);
     }
 }

--- a/crates/aivcs-core/tests/promote_validator.rs
+++ b/crates/aivcs-core/tests/promote_validator.rs
@@ -1,0 +1,164 @@
+use aivcs_core::domain::agent_spec::AgentSpec;
+use aivcs_core::domain::error::AivcsError;
+use aivcs_core::ReleaseRegistryApi;
+use oxidized_state::fakes::MemoryReleaseRegistry;
+
+fn make_spec(seed: &str) -> AgentSpec {
+    AgentSpec::new(
+        "abc123def456abc123def456abc123def456abc1".to_string(),
+        format!("graph-{}", seed),
+        format!("prompts-{}", seed),
+        format!("tools-{}", seed),
+        format!("config-{}", seed),
+    )
+    .expect("make_spec")
+}
+
+fn api() -> ReleaseRegistryApi<MemoryReleaseRegistry> {
+    ReleaseRegistryApi::new(MemoryReleaseRegistry::new())
+}
+
+#[tokio::test]
+async fn valid_spec_promotes_to_registry() {
+    let api = api();
+    let spec = make_spec("v1");
+
+    let record = api
+        .promote("my-agent", &spec, "ci", None, None)
+        .await
+        .expect("valid spec should promote");
+
+    assert_eq!(record.name, "my-agent");
+    assert_eq!(record.spec_digest.as_str(), spec.spec_digest);
+}
+
+#[tokio::test]
+async fn promote_rejected_when_tools_digest_empty() {
+    let api = api();
+    let mut spec = make_spec("v1");
+    spec.tools_digest = String::new();
+
+    let err = api
+        .promote("agent", &spec, "ci", None, None)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, AivcsError::InvalidAgentSpec(ref msg) if msg.contains("tools_digest")),
+        "unexpected error: {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn promote_rejected_when_graph_digest_empty() {
+    let api = api();
+    let mut spec = make_spec("v1");
+    spec.graph_digest = String::new();
+
+    let err = api
+        .promote("agent", &spec, "ci", None, None)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, AivcsError::InvalidAgentSpec(ref msg) if msg.contains("graph_digest")),
+        "unexpected error: {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn promote_rejected_when_prompts_digest_empty() {
+    let api = api();
+    let mut spec = make_spec("v1");
+    spec.prompts_digest = String::new();
+
+    let err = api
+        .promote("agent", &spec, "ci", None, None)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, AivcsError::InvalidAgentSpec(ref msg) if msg.contains("prompts_digest")),
+        "unexpected error: {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn promote_rejected_when_config_digest_empty() {
+    let api = api();
+    let mut spec = make_spec("v1");
+    spec.config_digest = String::new();
+
+    let err = api
+        .promote("agent", &spec, "ci", None, None)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, AivcsError::InvalidAgentSpec(ref msg) if msg.contains("config_digest")),
+        "unexpected error: {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn promote_rejected_when_git_sha_empty() {
+    let api = api();
+    let mut spec = make_spec("v1");
+    spec.git_sha = String::new();
+
+    let err = api
+        .promote("agent", &spec, "ci", None, None)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, AivcsError::InvalidAgentSpec(ref msg) if msg.contains("git_sha")),
+        "unexpected error: {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn promote_rejected_when_spec_digest_mismatches_components() {
+    let api = api();
+    let mut spec = make_spec("v1");
+    // Tamper with a component after spec_digest was computed
+    spec.graph_digest = "graph-TAMPERED".to_string();
+
+    let err = api
+        .promote("agent", &spec, "ci", None, None)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, AivcsError::DigestMismatch { .. }),
+        "expected DigestMismatch, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn component_check_precedes_digest_check() {
+    let api = api();
+    let mut spec = make_spec("v1");
+    // Empty a component AND tamper another — component check should fire first
+    spec.tools_digest = String::new();
+    spec.graph_digest = "tampered".to_string();
+
+    let err = api
+        .promote("agent", &spec, "ci", None, None)
+        .await
+        .unwrap_err();
+
+    // graph_digest is checked before tools_digest but "tampered" is non-empty,
+    // so prompts_digest (non-empty) passes, tools_digest (empty) should be the error
+    assert!(
+        matches!(err, AivcsError::InvalidAgentSpec(ref msg) if msg.contains("tools_digest")),
+        "expected tools_digest error first, got: {:?}",
+        err
+    );
+}


### PR DESCRIPTION
## Summary
- Add `validate_spec_for_promote` in `ReleaseRegistryApi` to validate `AgentSpec` before promoting
- Check all component digests (graph, prompts, tools, config) are non-empty
- Verify `git_sha` is present and `spec_digest` matches recomputed hash
- CLI `release promote` now accepts `--git-sha`, `--graph-digest`, `--prompts-digest`, `--tools-digest`, `--config-digest` instead of raw `--digest`

Closes #29
Refs #10

## Test plan
- [x] 8 integration tests in `promote_validator.rs`: happy path, missing tool, missing schema components, digest mismatch, validation ordering
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)