### PR TITLE
docs: M5-PR2 operator docs, runbooks, and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ echo '{"step": 1, "memory": "learned X"}' > state.json
 | `env` | Environment management (Nix/Attic integration) |
 | `fork` | Fork multiple parallel branches for exploration |
 | `trace` | Time-travel debugging - show reasoning trace |
+| `replay` | Replay a recorded run artifact by run ID |
+| `diff-runs` | Diff the tool-call sequences of two runs |
 
 ### Environment Commands (Phase 2)
 
@@ -104,6 +106,14 @@ aivcs trace main
 # Show trace with more depth
 aivcs trace experiment-0 --depth 50
 ```
+
+## Documentation
+
+- [Getting Started](docs/getting-started.md) — prerequisites, install, first-run walkthrough
+- [Architecture](docs/architecture.md) — crate layers, data flow, key abstractions
+- [Local Development](docs/runbooks/local-development.md) — build, test, dev workflows
+- [Database Configuration](docs/runbooks/database-configuration.md) — in-memory, local, cloud setup
+- [CI Troubleshooting](docs/runbooks/ci-troubleshooting.md) — common failures, reproduce locally
 
 ## Crate Structure
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,93 @@
+# AIVCS Architecture
+
+## Crate Layers
+
+```
+Layer 4  aivcs-cli          Clap CLI, command dispatch
+Layer 3  semantic-rag-merge  Memory vector diff + heuristic conflict resolution
+Layer 2  nix-env-manager     Nix Flake hashing + Attic binary cache
+Layer 1  aivcs-core          Domain logic, CAS, recording, replay, parallel fork
+Layer 0  oxidized-state      SurrealDB persistence (snapshots, commits, branches, runs)
+         aivcsd              Daemon stub (placeholder)
+```
+
+### Dependency Flow
+
+```
+aivcs-cli ──► aivcs-core ──► oxidized-state
+                           ──► nix-env-manager
+                           ──► semantic-rag-merge ──► oxidized-state
+```
+
+## Key Abstractions
+
+### CommitId (content-addressed)
+
+A composite SHA-256 hash derived from `logic_hash + state_digest + env_hash`. Ensures that identical agent state, source code, and environment always produce the same commit ID.
+
+### SurrealHandle (Layer 0)
+
+Wraps a SurrealDB connection (in-memory or WebSocket). Provides CRUD for:
+
+- `SnapshotRecord` — JSON state blobs keyed by commit hash
+- `CommitRecord` — commit metadata (parents, message, author, timestamp)
+- `BranchRecord` — named pointers to commit hashes
+- `GraphEdge` — parent → child edges for history traversal
+- `MemoryRecord` — key-value memory vectors for semantic merge
+
+### CasStore / FsCasStore (Layer 1)
+
+Content-addressed store with SHA-256 digests. `FsCasStore` writes blobs to disk under `.aivcs/cas/`. Used during `snapshot` to deduplicate state.
+
+### RunLedger (Layer 0)
+
+Trait for recording execution runs. Implementations:
+
+- `MemoryRunLedger` — in-memory (tests)
+- `SurrealRunLedger` — persisted to SurrealDB
+
+Each run consists of `RunEvent` records (seq, kind, payload, timestamp) that can be replayed deterministically.
+
+### GraphRunRecorder (Layer 1)
+
+Domain-level event recorder that maps `aivcs_core::Event` variants to `RunEvent` entries and persists them through the `RunLedger`.
+
+### ReleaseRegistry (Layer 0)
+
+Tracks per-agent release history. Supports `promote` (append new release), `current` (latest pointer), `rollback` (restore previous), and `history` (ordered list).
+
+### ParallelManager (Layer 1)
+
+Tracks branch scores and step counts during parallel exploration. `fork_agent_parallel` spawns N concurrent Tokio tasks that each create a branch + commit + snapshot from a parent commit.
+
+## Data Flow: Snapshot Command
+
+```
+CLI: aivcs snapshot --state state.json --branch main
+  │
+  ├─ Read state.json
+  ├─ Detect git HEAD SHA
+  ├─ Generate logic hash (Rust src) + env hash (flake.lock)
+  ├─ CAS put → Digest
+  ├─ CommitId::new(logic, state_digest, env)
+  ├─ SurrealHandle::save_snapshot(commit_id, state)
+  ├─ SurrealHandle::save_commit(record)
+  ├─ SurrealHandle::save_commit_graph_edge(child, parent)
+  └─ SurrealHandle::save_branch(updated head)
+```
+
+## Data Flow: Semantic Merge
+
+```
+CLI: aivcs merge feature --target main
+  │
+  ├─ Resolve branch heads → source_commit, target_commit
+  ├─ semantic_merge(handle, source, target, msg, author)
+  │   ├─ Load memories for both commits
+  │   ├─ diff_memory_vectors → VectorStoreDelta
+  │   ├─ resolve_conflict_state (heuristic: prefer longer content)
+  │   ├─ synthesize_memory → merged memories
+  │   ├─ Save merged snapshot + commit + graph edges
+  │   └─ Return MergeResult
+  └─ Update target branch head
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,86 @@
+# Getting Started with AIVCS
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+|---|---|---|
+| Rust toolchain | stable (1.75+) | Install via [rustup](https://rustup.rs/) |
+| Git | 2.x | For SHA linking and repo detection |
+| Nix *(optional)* | 2.18+ | Only needed for `aivcs env` commands |
+| Attic *(optional)* | latest | Only needed for binary cache features |
+
+## Installation
+
+```bash
+# Clone
+git clone https://github.com/stevedores-org/aivcs.git
+cd aivcs
+
+# Build release binary
+cargo build --release
+
+# The binary is at:
+./target/release/aivcs --version
+```
+
+## First-Run Walkthrough
+
+### 1. Initialise a repository
+
+```bash
+aivcs init
+```
+
+This creates an initial commit and a `main` branch in the backing SurrealDB store.
+
+### 2. Create a state snapshot
+
+```bash
+echo '{"step": 1, "memory": "learned X"}' > state.json
+aivcs snapshot --state state.json --message "First snapshot"
+```
+
+### 3. View history
+
+```bash
+aivcs log
+```
+
+### 4. Branch and explore
+
+```bash
+aivcs branch create experiment-1
+aivcs snapshot --state state.json --message "Experiment" --branch experiment-1
+```
+
+### 5. Merge back
+
+```bash
+aivcs merge experiment-1 --target main
+```
+
+### 6. Restore a previous state
+
+```bash
+aivcs restore <commit-id> --output restored.json
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `SURREALDB_ENDPOINT` | *(in-memory)* | WebSocket URL for SurrealDB Cloud |
+| `SURREALDB_USERNAME` | — | Database user |
+| `SURREALDB_PASSWORD` | — | Database password |
+| `SURREALDB_NAMESPACE` | `aivcs` | SurrealDB namespace |
+| `SURREALDB_DATABASE` | `main` | SurrealDB database name |
+| `ATTIC_SERVER` | — | Attic binary cache server URL |
+| `ATTIC_CACHE` | — | Attic cache name |
+| `ATTIC_TOKEN` | — | Attic authentication token |
+| `RUST_LOG` | `info` | Tracing filter (e.g. `debug`, `aivcs_core=trace`) |
+
+## Next Steps
+
+- [Architecture overview](./architecture.md)
+- [Local development runbook](./runbooks/local-development.md)
+- [Database configuration runbook](./runbooks/database-configuration.md)

--- a/docs/runbooks/ci-troubleshooting.md
+++ b/docs/runbooks/ci-troubleshooting.md
@@ -1,0 +1,77 @@
+# CI Troubleshooting Runbook
+
+## CI Overview
+
+CI runs on every push to `develop`/`main` and on all pull requests. Two jobs:
+
+| Job | Tool | Blocking? |
+|---|---|---|
+| `local-ci` | `stevedores-org/local-ci` (Go) | Yes |
+| `nix-report` | `nix flake check` | No (report-only) |
+
+### local-ci
+
+`local-ci --json` discovers and runs checks defined in the repository. For AIVCS this includes:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace`
+
+### nix-report
+
+Runs `nix flake check` and uploads the log as a build artifact. Failures here do **not** block merge.
+
+## Common Failures
+
+### Clippy warnings
+
+```
+error: ... implied by `-D warnings`
+```
+
+**Fix:** Run `cargo clippy --all -- -D warnings` locally, fix all warnings, then push.
+
+### Format check failure
+
+```
+Diff in src/foo.rs
+```
+
+**Fix:** Run `cargo fmt --all` locally, commit the formatted files.
+
+### Test failure
+
+**Fix:** Run `cargo test --all` locally. For flaky tests involving SurrealDB, ensure no global state leaks between tests (each test should call `SurrealHandle::setup_db()` for a fresh in-memory instance).
+
+### local-ci not found
+
+```
+local-ci: command not found
+```
+
+CI installs it via `go install github.com/stevedores-org/local-ci@latest`. If building locally:
+
+```bash
+go install github.com/stevedores-org/local-ci@latest
+local-ci --json
+```
+
+### Nix flake check failure (non-blocking)
+
+Check the uploaded `nix-flake-check-log` artifact in the GitHub Actions run. Common issues:
+
+- Missing flake input → update `flake.lock` with `nix flake update`
+- Build failure → check Rust compilation errors in the Nix derivation
+
+## Reproduce CI Locally
+
+```bash
+# Exact CI sequence
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+
+# Or use local-ci directly
+go install github.com/stevedores-org/local-ci@latest
+local-ci --json
+```

--- a/docs/runbooks/database-configuration.md
+++ b/docs/runbooks/database-configuration.md
@@ -1,0 +1,67 @@
+# Database Configuration Runbook
+
+AIVCS uses SurrealDB as its backing store. Three deployment modes are supported.
+
+## In-Memory (Default)
+
+No configuration needed. When `SURREALDB_ENDPOINT` is unset, the library automatically starts an embedded in-memory SurrealDB instance. Data is lost when the process exits.
+
+Best for: local development, testing, CI.
+
+## Local SurrealDB
+
+Run a local SurrealDB server:
+
+```bash
+# Install SurrealDB
+curl -sSf https://install.surrealdb.com | sh
+
+# Start local server (file-backed for persistence)
+surreal start file:aivcs.db --user root --pass root
+```
+
+Configure AIVCS to connect:
+
+```bash
+export SURREALDB_ENDPOINT=ws://127.0.0.1:8000
+export SURREALDB_USERNAME=root
+export SURREALDB_PASSWORD=root
+export SURREALDB_NAMESPACE=aivcs
+export SURREALDB_DATABASE=main
+```
+
+Best for: local development with persistent data.
+
+## SurrealDB Cloud
+
+1. Create an account at [SurrealDB Cloud](https://surrealdb.com/cloud)
+2. Provision an instance
+3. Create a database user at **Authentication > Database Users** with Editor or Owner role
+
+```bash
+export SURREALDB_ENDPOINT=wss://YOUR_INSTANCE.aws-use1.surrealdb.cloud
+export SURREALDB_USERNAME=your_username
+export SURREALDB_PASSWORD=your_password
+export SURREALDB_NAMESPACE=aivcs
+export SURREALDB_DATABASE=main
+```
+
+Best for: production, shared team environments.
+
+## Connection Behaviour
+
+`SurrealHandle::setup_from_env()` checks environment variables in this order:
+
+1. If `SURREALDB_ENDPOINT` is set → connect via WebSocket
+2. Otherwise → start embedded in-memory instance
+
+The schema (`create_schema()`) runs automatically on every connection, creating tables and indexes idempotently.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| "Failed to connect to AIVCS database" | Endpoint unreachable | Check `SURREALDB_ENDPOINT` and network |
+| "Authentication failed" | Wrong credentials | Verify `SURREALDB_USERNAME` / `SURREALDB_PASSWORD` |
+| Data missing after restart | Using in-memory mode | Set `SURREALDB_ENDPOINT` for persistence |
+| "Table not found" errors | Schema not created | Ensure `create_schema()` runs (automatic on connect) |

--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -1,0 +1,73 @@
+# Local Development Runbook
+
+## Clone and Build
+
+```bash
+git clone https://github.com/stevedores-org/aivcs.git
+cd aivcs
+cargo build
+```
+
+## Running Tests
+
+```bash
+# Full test suite (~195 tests)
+cargo test --all
+
+# Single crate
+cargo test -p oxidized-state
+
+# Single test by name
+cargo test test_snapshot_is_atomic
+
+# With output
+cargo test -- --nocapture
+```
+
+## Linting
+
+```bash
+# Clippy (CI enforces zero warnings)
+cargo clippy --all -- -D warnings
+
+# Formatting
+cargo fmt --all -- --check
+```
+
+## Logging
+
+Set `RUST_LOG` for fine-grained control:
+
+```bash
+# Default info level
+RUST_LOG=info cargo run -- log
+
+# Debug for core crate only
+RUST_LOG=aivcs_core=debug cargo run -- snapshot --state state.json
+
+# Trace everything
+RUST_LOG=trace cargo run -- merge feature --target main
+```
+
+## Dev Workflows
+
+### Add a new CLI command
+
+1. Add a variant to `Commands` enum in `crates/aivcs-cli/src/main.rs`
+2. Add a match arm in the `main()` dispatch
+3. Implement `cmd_<name>()` function
+4. Add tests in the `#[cfg(test)] mod tests` block
+
+### Add a new domain type
+
+1. Create a file in `crates/aivcs-core/src/domain/`
+2. Export from `crates/aivcs-core/src/domain/mod.rs`
+3. Re-export from `crates/aivcs-core/src/lib.rs`
+4. Write co-located `#[cfg(test)] mod tests`
+
+### Add a new SurrealDB record type
+
+1. Define the struct in `crates/oxidized-state/src/schema.rs`
+2. Add CRUD methods to `SurrealHandle` in `crates/oxidized-state/src/handle.rs`
+3. Add schema creation to `create_schema()` if needed
+4. Write tests using `SurrealHandle::setup_db()` (in-memory)


### PR DESCRIPTION
## Summary
- Adds `docs/getting-started.md` — prerequisites, install, first-run walkthrough, env vars table
- Adds `docs/architecture.md` — crate layers, data flow, key abstractions (RunLedger, CasStore, ReleaseRegistry)
- Adds `docs/runbooks/local-development.md` — clone, build, test, RUST_LOG, dev workflows
- Adds `docs/runbooks/database-configuration.md` — in-memory / local / SurrealDB Cloud setup
- Adds `docs/runbooks/ci-troubleshooting.md` — local-ci overview, common failures, reproduce locally
- Updates README with `replay` and `diff-runs` commands and links to new docs

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (no code changes)
- [ ] Verify markdown renders correctly on GitHub

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)