### PR TITLE
feat(release): M5-PR3 release checklist, changelog, workflow, publish gating

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: aivcs-linux-amd64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: aivcs-macos-arm64
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Rename binary
+        run: |
+          cp target/${{ matrix.target }}/release/aivcs ${{ matrix.artifact }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts/aivcs-linux-amd64/aivcs-linux-amd64
+            artifacts/aivcs-macos-arm64/aivcs-macos-arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-02-18
+
+### Added
+- Snapshot core: commit, restore, branch, log commands
+- Content-addressed store (CAS) with SHA-256 digests
+- SurrealDB backend (in-memory and WebSocket/Cloud)
+- Nix Flake environment hashing and Attic binary cache integration
+- Semantic merge with memory vector diffing and heuristic conflict resolution
+- Parallel branch forking with concurrent Tokio tasks
+- Branch pruning based on score thresholds
+- Time-travel trace debugging
+- Run recording and replay with deterministic digest verification
+- Tool-call sequence diffing (LCS-based)
+- Diff commands for runs and state
+- Release registry with promote/rollback support
+- Eval suite with deterministic runner and scorer framework

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,36 @@
+# Release Checklist
+
+## Versioning Policy
+
+AIVCS follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** — breaking API or storage format changes
+- **MINOR** — new features, backward-compatible
+- **PATCH** — bug fixes, documentation
+
+The workspace version in `Cargo.toml` is the single source of truth. All crates inherit `version.workspace = true`.
+
+## Pre-Release
+
+- [ ] All CI checks pass on `develop` (`cargo fmt`, `cargo clippy`, `cargo test`)
+- [ ] `CHANGELOG.md` is updated with the new version entry
+- [ ] Workspace version in `Cargo.toml` is bumped
+- [ ] Version consistency test passes: `cargo test version_consistency`
+- [ ] No `TODO` or `FIXME` items blocking release
+- [ ] Documentation in `docs/` is up to date
+
+## Release
+
+- [ ] Merge `develop` into `main` via pull request
+- [ ] Tag the merge commit: `git tag v<VERSION> && git push origin v<VERSION>`
+- [ ] Verify the `release.yml` GitHub Actions workflow completes:
+  - Linux binary built
+  - macOS binary built
+  - GitHub Release created with both binaries attached
+- [ ] Verify the release page has correct notes and artifacts
+
+## Post-Release
+
+- [ ] Announce the release (if applicable)
+- [ ] Bump workspace version in `Cargo.toml` to next dev version (e.g. `0.2.0`)
+- [ ] Create a new `## [Unreleased]` section in `CHANGELOG.md`

--- a/crates/aivcs-cli/Cargo.toml
+++ b/crates/aivcs-cli/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+publish = false
 
 [[bin]]
 name = "aivcs"

--- a/crates/aivcs-core/Cargo.toml
+++ b/crates/aivcs-core/Cargo.toml
@@ -40,3 +40,4 @@ tempfile.workspace = true
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 tempfile.workspace = true
+toml = "0.8"

--- a/crates/aivcs-core/tests/version_consistency.rs
+++ b/crates/aivcs-core/tests/version_consistency.rs
@@ -1,0 +1,84 @@
+//! Ensures all workspace crates use `version.workspace = true` and that
+//! the workspace version is consistent across all Cargo.toml files.
+
+use std::path::Path;
+
+/// Read the workspace version from the root Cargo.toml.
+fn workspace_version() -> String {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+    let root_toml = std::fs::read_to_string(root.join("Cargo.toml")).unwrap();
+    let doc: toml::Value = root_toml.parse().unwrap();
+    doc["workspace"]["package"]["version"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Read the resolved version from a crate's Cargo.toml.
+/// If the crate uses `version.workspace = true`, Cargo resolves it at
+/// compile time, so we check that the CARGO_PKG_VERSION matches.
+fn crate_version(manifest_dir: &Path) -> String {
+    let toml_str = std::fs::read_to_string(manifest_dir.join("Cargo.toml")).unwrap();
+    let doc: toml::Value = toml_str.parse().unwrap();
+
+    // Check if version.workspace = true
+    if let Some(pkg) = doc.get("package") {
+        if let Some(version) = pkg.get("version") {
+            if let Some(table) = version.as_table() {
+                if table.get("workspace").and_then(|v| v.as_bool()) == Some(true) {
+                    return "workspace".to_string();
+                }
+            }
+            if let Some(v) = version.as_str() {
+                return v.to_string();
+            }
+        }
+    }
+    panic!(
+        "Could not read version from {}",
+        manifest_dir.join("Cargo.toml").display()
+    );
+}
+
+#[test]
+fn all_crates_use_workspace_version() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    let crates = [
+        "crates/aivcs-core",
+        "crates/aivcs-cli",
+        "crates/aivcsd",
+        "crates/oxidized-state",
+        "crates/nix-env-manager",
+        "crates/semantic-rag-merge",
+    ];
+
+    for krate in &crates {
+        let manifest_dir = workspace_root.join(krate);
+        let version = crate_version(&manifest_dir);
+        assert_eq!(
+            version, "workspace",
+            "{} should use version.workspace = true, got version = {:?}",
+            krate, version
+        );
+    }
+}
+
+#[test]
+fn workspace_version_matches_cargo_pkg() {
+    let ws_version = workspace_version();
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    assert_eq!(
+        ws_version, pkg_version,
+        "workspace version ({}) != CARGO_PKG_VERSION ({})",
+        ws_version, pkg_version
+    );
+}

--- a/crates/aivcsd/Cargo.toml
+++ b/crates/aivcsd/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+publish = false
 
 [[bin]]
 name = "aivcsd"


### PR DESCRIPTION
## Summary
- Adds `RELEASE_CHECKLIST.md` — pre-release, release, post-release steps + versioning policy
- Adds `CHANGELOG.md` — initial 0.1.0 entry using Keep a Changelog format
- Adds `.github/workflows/release.yml` — triggered on `v*` tags; builds linux+macOS binaries, creates GitHub Release
- Adds `version_consistency.rs` integration test asserting all crates use `version.workspace = true` and match workspace version
- Adds `publish = false` to `aivcs-cli` and `aivcsd` Cargo.toml (binary crates should not be published to crates.io)

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes including new `version_consistency` tests
- [ ] Validate `release.yml` YAML syntax (well-formed, uses standard actions)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)