### PR TITLE
feat(deploy): M4-PR3 deploy-by-digest reference runner

### DIFF
--- a/crates/aivcs-core/src/deploy_runner.rs
+++ b/crates/aivcs-core/src/deploy_runner.rs
@@ -1,0 +1,132 @@
+//! Deploy-by-digest reference runner.
+//!
+//! Runs an agent by `AgentSpec` digest through `RunLedger` and emits a minimal,
+//! deterministic event sequence for replay/golden validation.
+
+use chrono::{DateTime, Utc};
+use oxidized_state::{
+    ContentDigest, RunEvent, RunId, RunLedger, RunMetadata, RunSummary, StorageError,
+};
+
+use crate::domain::{AivcsError, Result};
+
+/// Output of a deploy-by-digest run.
+#[derive(Debug, Clone)]
+pub struct DeployRunOutput {
+    pub run_id: RunId,
+    pub emitted_events: usize,
+}
+
+/// Reference runner for deploy-by-digest execution.
+pub struct DeployByDigestRunner;
+
+impl DeployByDigestRunner {
+    /// Run deploy-by-digest using current UTC time for event timestamps.
+    pub async fn run(
+        ledger: &dyn RunLedger,
+        spec_digest: &ContentDigest,
+        agent_name: &str,
+    ) -> Result<DeployRunOutput> {
+        let now = Utc::now();
+        Self::run_at(ledger, spec_digest, agent_name, now).await
+    }
+
+    /// Run deploy-by-digest at a fixed timestamp (used for deterministic tests).
+    pub async fn run_at(
+        ledger: &dyn RunLedger,
+        spec_digest: &ContentDigest,
+        agent_name: &str,
+        timestamp: DateTime<Utc>,
+    ) -> Result<DeployRunOutput> {
+        let metadata = RunMetadata {
+            git_sha: None,
+            agent_name: agent_name.to_string(),
+            tags: serde_json::json!({
+                "mode": "deploy_by_digest",
+            }),
+        };
+
+        let run_id = ledger
+            .create_run(spec_digest, metadata)
+            .await
+            .map_err(storage_err)?;
+
+        let events = vec![
+            RunEvent {
+                seq: 1,
+                kind: "deploy_started".to_string(),
+                payload: serde_json::json!({
+                    "spec_digest": spec_digest.as_str(),
+                }),
+                timestamp,
+            },
+            RunEvent {
+                seq: 2,
+                kind: "agent_executed".to_string(),
+                payload: serde_json::json!({
+                    "agent_name": agent_name,
+                    "spec_digest": spec_digest.as_str(),
+                }),
+                timestamp,
+            },
+            RunEvent {
+                seq: 3,
+                kind: "deploy_completed".to_string(),
+                payload: serde_json::json!({
+                    "success": true,
+                }),
+                timestamp,
+            },
+        ];
+
+        for event in events {
+            ledger
+                .append_event(&run_id, event)
+                .await
+                .map_err(storage_err)?;
+        }
+
+        let summary = RunSummary {
+            total_events: 3,
+            final_state_digest: Some(spec_digest.clone()),
+            duration_ms: 0,
+            success: true,
+        };
+        ledger
+            .complete_run(&run_id, summary)
+            .await
+            .map_err(storage_err)?;
+
+        Ok(DeployRunOutput {
+            run_id,
+            emitted_events: 3,
+        })
+    }
+}
+
+fn storage_err(e: StorageError) -> AivcsError {
+    AivcsError::StorageError(e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxidized_state::fakes::MemoryRunLedger;
+    use oxidized_state::RunStatus;
+
+    #[tokio::test]
+    async fn deploy_run_records_spec_digest_and_completes() {
+        let ledger = MemoryRunLedger::new();
+        let digest = ContentDigest::from_bytes(b"agent-spec-v1");
+
+        let output = DeployByDigestRunner::run(&ledger, &digest, "agent-alpha")
+            .await
+            .expect("deploy run");
+
+        assert_eq!(output.emitted_events, 3);
+        let run = ledger.get_run(&output.run_id).await.expect("get run");
+        assert_eq!(run.spec_digest, digest);
+        assert_eq!(run.status, RunStatus::Completed);
+        assert_eq!(run.summary.expect("summary").total_events, 3);
+    }
+}

--- a/crates/aivcs-core/src/lib.rs
+++ b/crates/aivcs-core/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod cas;
 pub mod compat;
+pub mod deploy_runner;
 pub mod diff;
 pub mod domain;
 pub mod event_adapter;
@@ -54,6 +55,7 @@ pub use parallel::{
 pub use compat::{
     evaluate_compat, CompatRule, CompatRuleSet, CompatVerdict, CompatViolation, PromoteContext,
 };
+pub use deploy_runner::{DeployByDigestRunner, DeployRunOutput};
 pub use diff::node_paths::{
     diff_node_paths, extract_node_path, NodeDivergence, NodePathDiff, NodeStep,
 };

--- a/crates/aivcs-core/tests/deploy_by_digest.rs
+++ b/crates/aivcs-core/tests/deploy_by_digest.rs
@@ -1,0 +1,60 @@
+use aivcs_core::{replay_run, DeployByDigestRunner};
+use chrono::{DateTime, Utc};
+use oxidized_state::fakes::MemoryRunLedger;
+use oxidized_state::{ContentDigest, RunEvent};
+
+#[tokio::test]
+async fn deploy_by_digest_matches_replay_golden() {
+    let ledger = MemoryRunLedger::new();
+    let digest = ContentDigest::from_bytes(b"spec-deploy-golden-v1");
+    let ts = DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+        .expect("parse timestamp")
+        .with_timezone(&Utc);
+
+    let output = DeployByDigestRunner::run_at(&ledger, &digest, "agent-golden", ts)
+        .await
+        .expect("run by digest");
+
+    let (events, summary) = replay_run(&ledger, &output.run_id.0).await.expect("replay");
+
+    let expected_events = vec![
+        RunEvent {
+            seq: 1,
+            kind: "deploy_started".to_string(),
+            payload: serde_json::json!({
+                "spec_digest": digest.as_str(),
+            }),
+            timestamp: ts,
+        },
+        RunEvent {
+            seq: 2,
+            kind: "agent_executed".to_string(),
+            payload: serde_json::json!({
+                "agent_name": "agent-golden",
+                "spec_digest": digest.as_str(),
+            }),
+            timestamp: ts,
+        },
+        RunEvent {
+            seq: 3,
+            kind: "deploy_completed".to_string(),
+            payload: serde_json::json!({
+                "success": true,
+            }),
+            timestamp: ts,
+        },
+    ];
+
+    let expected_digest =
+        ContentDigest::from_bytes(&serde_json::to_vec(&expected_events).expect("serialize events"));
+
+    assert_eq!(events.len(), expected_events.len());
+    for (actual, expected) in events.iter().zip(expected_events.iter()) {
+        assert_eq!(actual.seq, expected.seq);
+        assert_eq!(actual.kind, expected.kind);
+        assert_eq!(actual.payload, expected.payload);
+        assert_eq!(actual.timestamp, expected.timestamp);
+    }
+    assert_eq!(summary.event_count, 3);
+    assert_eq!(summary.replay_digest, expected_digest.as_str());
+}


### PR DESCRIPTION
## Summary
- add `aivcs_core::DeployByDigestRunner` reference runner to execute by `AgentSpec` digest
- emit deterministic run ledger events (`deploy_started`, `agent_executed`, `deploy_completed`) and complete run records
- include fixed-timestamp execution path for deterministic golden testing
- add replay-golden integration test validating deploy behavior digest matches expected replay digest

## Scope
Implements #30 (M4-PR3) as a single atomic PR on `develop`.

## Validation
- `/tmp/local-ci --verbose`
- `cargo clippy -p aivcs-core --all-targets -- -D warnings`
- `cargo test -p aivcs-core`

Refs #10
Refs #30
