### PR TITLE
fix(deploy): follow-up to PR #81 summary semantics

### DIFF
--- a/crates/aivcs-core/tests/deploy_by_digest.rs
+++ b/crates/aivcs-core/tests/deploy_by_digest.rs
@@ -1,7 +1,7 @@
 use aivcs_core::{replay_run, DeployByDigestRunner};
 use chrono::{DateTime, Utc};
 use oxidized_state::fakes::MemoryRunLedger;
-use oxidized_state::{ContentDigest, RunEvent};
+use oxidized_state::{ContentDigest, RunEvent, RunLedger};
 
 #[tokio::test]
 async fn deploy_by_digest_matches_replay_golden() {
@@ -57,4 +57,8 @@ async fn deploy_by_digest_matches_replay_golden() {
     }
     assert_eq!(summary.event_count, 3);
     assert_eq!(summary.replay_digest, expected_digest.as_str());
+
+    let run = ledger.get_run(&output.run_id).await.expect("get run");
+    let run_summary = run.summary.expect("run summary");
+    assert!(run_summary.final_state_digest.is_none());
 }


### PR DESCRIPTION
## Summary
Follow-up for merged PR #81.

- set `RunSummary.final_state_digest` to `None` for deploy-by-digest reference runner (no final state blob is materialized)
- replace hardcoded `duration_ms: 0` with measured elapsed duration via `Instant`
- add assertions in unit/integration tests to lock the corrected summary semantics

## Why
Addresses review findings from #81:
1. `final_state_digest` was incorrectly set to spec digest.
2. `duration_ms` was hardcoded and non-informative.

## Validation
- `/tmp/local-ci --verbose`

Refs #81
