### PR TITLE
docs: preserve strategic vision from issue #49

### DIFF
--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,119 @@
+# Why We Do What We Do
+
+> Preserved from [issue #49](https://github.com/stevedores-org/aivcs/issues/49).
+> This is a strategic rationale document, not an active work item.
+
+## 1. The Productivity Paradox in Agentic AI Engineering
+
+The contemporary software engineering landscape is witnessing a paradigm shift of a magnitude not seen since the transition from monolithic mainframes to distributed microservices. This shift is driven by the ascendancy of autonomous AI agents—systems that are not merely programmed but trained, prompted, and orchestrated to exhibit probabilistic behaviors. As the Stevedores organization seeks to drive productivity for AI agent builders to the "next level," it faces a fundamental friction: the tooling that defines the modern developer experience, specifically the Git version control system and the GitHub platform, was architected for a deterministic, text-centric era that is increasingly divergent from the needs of agentic AI.
+
+The core of this productivity paradox lies in the nature of the artifacts being managed. Traditional software repositories consist of source code—lightweight, text-based, and human-readable logic where the relationship between input and output is deterministic. In contrast, AI agent development involves a complex triad of artifacts: code (logic), model weights (massive binary state), and prompts (semantic instructions). Standard version control systems (VCS) treat these distinct entities with a uniform indifference, managing them all as files. This reductionist approach introduces significant inefficiencies. It forces developers to contend with "binary bloat," where repositories balloon into gigabytes of history that throttle network bandwidth and local disk I/O. It creates "semantic blindness," where a critical change in a system prompt is treated identically to a comment typo, obscuring the impact on agent behavior. Furthermore, it fails to address the "reproducibility crisis," where the non-deterministic nature of AI models is compounded by the fragility of development environments, leading to the infamous "it works on my machine" operational hazard.
+
+To resolve these bottlenecks, the organization must evaluate whether to optimize the incumbent infrastructure (Git/GitHub), adopt a specialized overlay (stevedores-org/aivcs), or engineer a bespoke solution using high-performance primitives (stevedores-org/gitoxide). This report provides an exhaustive analysis of these three strategic pathways, culminating in a recommendation for a hybrid architecture that leverages the raw performance of Rust and the hermetic reliability of Nix to construct a private, sovereign development forge.
+
+### 1.1 The Binary Artifact Bottleneck
+
+The most immediate impediment to AI agent productivity is the mismanagement of large binary files. Deep learning models, embeddings indices, and training datasets are fundamentally different from source code; they do not benefit from line-by-line differencing and compression. When a standard Git repository is tasked with managing a 10GB model checkpoint, the underlying architecture struggles. Git is designed as a distributed system, meaning every clone operation attempts to retrieve the full history of every file. In an active AI project where model weights are updated frequently, the repository size grows exponentially, turning a simple `git clone` operation into a protracted, coffee-break-inducing delay that severs the developer's flow state.
+
+The industry-standard remediation for this issue is Git Large File Storage (LFS), an extension that replaces large files with lightweight pointers while storing the actual blob on a central server. While LFS mitigates the initial cloning size, it introduces a "pointer hell" that complicates collaboration. LFS operations are often single-threaded and heavily network-bound, creating a performance bottleneck during push and pull operations. More critically, LFS relies on file-level deduplication. If an engineer fine-tunes a large language model (LLM), changing only a fraction of the weights, LFS forces the re-upload and storage of the entire binary blob. For a team iterating on agents rapidly, this results in massive bandwidth costs and storage redundancy, effectively penalizing frequent experimentation.
+
+### 1.2 The Crisis of Determinism and Environment Drift
+
+Beyond storage, the productivity of agent builders is sabotaged by environment drift. AI agents are hypersensitive to their runtime context; a minor discrepancy in CUDA driver versions, Python library dependencies, or system-level dynamic link libraries can cause an agent to behave non-deterministically or fail entirely. Standard Git repositories track code but only loosely define the environment through manifests like `requirements.txt` or `Dockerfile`. These manifests are descriptive, not prescriptive—they describe what should be installed, but they do not guarantee the exact binary state of the installation.
+
+This lack of hermeticity manifests acutely in Continuous Integration and Continuous Deployment (CI/CD) pipelines. Platforms like GitHub Actions typically provision fresh virtual machines for every run, necessitating the repetitive and time-consuming download of massive dependencies like PyTorch or TensorFlow. This adds significant latency to the feedback loop, forcing developers to wait ten to twenty minutes to verify a simple change. In a "next-level" productivity scenario, the environment itself must be treated as a first-class versioned artifact, instantly available and mathematically guaranteed to be identical across all development and production machines.
+
+### 1.3 Semantic Opacity in Prompt Engineering
+
+The third pillar of the productivity crisis is the inability of standard tools to understand the semantics of AI instructions. In modern agentic workflows, "prompts" are the new code. They are structured, logic-bearing instructions that dictate the agent's reasoning capabilities. However, when a developer modifies a system prompt, standard Git tools present a textual diff—a visual representation of added and removed lines. This diff fails to convey the semantic impact of the change. It cannot tell the reviewer whether the alteration strengthens a safety guardrail, weakens the agent's reasoning chain, or introduces a hallucination risk.
+
+Furthermore, complex agents are often architected as Directed Acyclic Graphs (DAGs), where nodes represent cognitive steps (e.g., "Reason," "Tool Use," "Reflect"). A change to the topology of this graph is difficult to visualize in a linear diff format. Without tools that understand the structure of the agent, code reviews become exercises in guesswork, increasing the risk of shipping defective intelligence to production.
+
+## 2. Architecture A: The Incumbent — Git & GitHub Enterprise
+
+The first strategic option is to double down on the industry standard: GitHub Enterprise. This path prioritizes stability and ecosystem integration over specialization. It relies on the hypothesis that the friction experienced by AI builders can be managed through plugins and operational discipline rather than architectural revolution.
+
+### 2.1 Ecosystem Integration and Feature Velocity
+
+GitHub's primary advantage is its ubiquity. It is the center of gravity for the open-source world and the default integration point for the vast majority of DevOps tooling. For AI builders, this means seamless connectivity with deployment platforms like Vercel, AWS, and Azure, as well as access to a massive marketplace of Actions.
+
+The platform has also begun to integrate AI-specific features directly into the workflow. GitHub Copilot Enterprise offers "agentic" capabilities within the editor, indexing private repositories to provide context-aware code completion and chat assistance. This can significantly accelerate the writing of boilerplate code and standard logic. Furthermore, GitHub Advanced Security provides mature scanning for secrets and vulnerabilities, a critical requirement for agents that may handle sensitive API keys or interact with proprietary data.
+
+### 2.2 The "Walled Garden" Limitations
+
+Despite these features, GitHub Enterprise fundamentally remains a general-purpose tool. Its architecture is optimized for the 99% of software that is web or systems code, not the 1% that is heavy AI development.
+
+| Feature Domain | Limitation | Impact on Agent Builders |
+|---|---|---|
+| Binary Management | Relies on Git LFS. High cost for storage/bandwidth; slow throughput. | Throttled Iteration: Developers hesitate to checkpoint frequently due to wait times. |
+| CI/CD Pipeline | Non-persistent runners; expensive per-minute billing for GPU instances. | Slow Feedback: Testing agents requires massive environment setup time on every run. |
+| Code Review | Text-based diffs only. No support for semantic prompt comparison or graph visualization. | Blind Reviews: Reviewers cannot assess the behavioral impact of prompt changes without manual testing. |
+| Extensibility | Closed-source core. Hooks are limited to client-side or predefined webhooks. | Rigid Workflow: Impossible to implement custom server-side optimization (e.g., smart weight caching). |
+
+The cost structure of GitHub Enterprise also presents a scaling challenge. GitHub charges per user and imposes strict limits on API usage and CI minutes. For an organization generating terabytes of training data and running thousands of agent evaluations, the "tax" of using a managed service can become prohibitive.
+
+Ultimately, opting for GitHub Enterprise is a decision to accept a "productivity ceiling." It offers a polished, secure floor, but it prevents the Stevedores organization from optimizing the deep infrastructure layers where the most significant AI bottlenecks reside.
+
+## 3. Architecture B: The Engine — Stevedores-org/Gitoxide
+
+The second option explores the feasibility of building a custom solution using stevedores-org/gitoxide. This project is a pure Rust implementation of the Git core, designed from the ground up to address the performance and safety deficiencies of the canonical C implementation.
+
+### 3.1 The Technical Superiority of Rust
+
+To understand why gitoxide is a viable contender, one must appreciate the limitations of the standard Git codebase. Canonical Git is a sprawling collection of C code and shell scripts that has accumulated decades of technical debt. It is single-threaded for many operations and relies on memory management practices that are prone to safety vulnerabilities.
+
+gitoxide, by contrast, leverages the Rust programming language's zero-cost abstractions and ownership model. This allows it to achieve thread safety without the heavy locking mechanisms that plague libraries like libgit2. Benchmarks indicate that gitoxide can outperform standard Git significantly in operations involving massive tree traversals, such as checkout and status, which are common bottlenecks in large AI monorepos.
+
+Furthermore, gitoxide offers a "max-pure" build configuration. This means it can compile into a static binary without requiring external C libraries like OpenSSL or zlib. This portability is a massive strategic advantage for building a "private GitHub" that needs to run on diverse hardware architectures, from ARM64 inference servers to Windows developer workstations, without the "dependency hell" of maintaining a C toolchain.
+
+### 3.2 Feasibility of Building a Private Forge
+
+gitoxide is primarily a library (the `gix` crate) rather than a standalone application server. It provides the low-level primitives to read, write, and manipulate Git objects with extreme efficiency. It supports the implementation of transport protocols (HTTP, SSH), which are the requisite communication channels for any Git server. However, a "Forge" (like GitHub) is more than just a Git server; it is a complex web application requiring user authentication, database management, pull request logic, issue tracking, and access control lists.
+
+Constructing a full-feature "private GitHub" solely on top of gitoxide would require the Stevedores engineering team to rebuild these commodity features from scratch. This represents a classic "undifferentiated heavy lifting" trap. While the team would gain complete control, they would also inherit the burden of maintaining security patches for a web frontend, designing UI/UX flows, and managing database migrations.
+
+**The Strategic Pivot:** The true value of gitoxide lies not in replacing the *interface* of GitHub, but in replacing its *engine*. By using gitoxide as the backend processor, Stevedores can implement custom server-side hooks that are impossible on GitHub Enterprise.
+
+## 4. Architecture C: The Specialist — Stevedores-org/AIVCS
+
+The third, and perhaps most intriguing, option is stevedores-org/aivcs. This is not merely a different Git client, but a "Layer 2" version control system designed specifically for the complexities of AI development. It integrates oxidizedgraph (a Rust implementation of LangGraph) and leverages the power of Nix and Attic for artifact management.
+
+### 4.1 The "Layer 2" Philosophy
+
+If standard Git is "Layer 1" (tracking changes in text files), AIVCS operates at "Layer 2" (tracking changes in systems and intelligence). The core philosophy here is that an AI agent cannot be defined by code alone; it is defined by the hermetic union of its code, its environment, and its data.
+
+**Nix Integration for Hermetic Builds:**
+AIVCS addresses the environment drift problem by integrating with Nix Flakes. Nix is a package manager that treats packages as immutable, content-addressable values. By defining the agent's environment in a `flake.nix` file, AIVCS ensures that every developer and every CI runner is using the mathematically identical version of Python, CUDA, and system libraries. This eliminates the "works on my machine" phenomenon entirely.
+
+**Attic for Binary Caching:**
+Instead of relying on the inefficient Git LFS, AIVCS utilizes Attic, a multi-tenant binary cache for Nix written in Rust. Attic offers superior deduplication capabilities compared to LFS. It understands the structure of the build artifacts and can cache them at a granular level. When a developer pulls an update, AIVCS doesn't just download files; it fetches the pre-compiled binaries and cached model weights from Attic, ensuring that the local environment is ready to run in seconds. This architecture essentially turns the "clone" operation into a "hydration" operation, where the local machine is instantly synchronized with the global state.
+
+### 4.2 Semantic Versioning with OxidizedGraph
+
+The inclusion of oxidizedgraph indicates that AIVCS is built to understand the topology of agentic workflows. Modern agents are often structured as graphs where nodes perform discrete cognitive tasks.
+
+**Graph Diffing:** Instead of showing line changes in a file, AIVCS can visualize the difference between two versions of an agent graph (e.g., "Node B now connects to Node D instead of Node C").
+
+**Static Analysis:** Because the graph is defined in Rust, AIVCS can perform static analysis to detect cycles, unreachable nodes, or type mismatches in the data flow before the code is even committed. This level of safety is unattainable with Python-based frameworks managed by standard Git.
+
+## 5. Comparative Analysis
+
+| Feature | Git / GitHub Enterprise | Custom Forge w/ Gitoxide | Hybrid Architecture (AIVCS) |
+|---|---|---|---|
+| Primary Philosophy | General Purpose / "Walled Garden" | High Performance / Low-Level | Specialized / "Layer 2" Control |
+| Git Engine | Proprietary / Libgit2 | Gitoxide (Pure Rust) | Gitoxide (Pure Rust) |
+| Binary Handling | Git LFS (Slow, Expensive) | Custom Implementation | Attic + Nix (Deduplicated) |
+| Reproducibility | Low (Docker/Actions) | Medium (Manual Hooks) | Maximum (Hermetic) |
+| Agent Intelligence | Agnostic (Text Diffs) | Agnostic | Native (OxidizedGraph) |
+| Maintenance Cost | Low (SaaS Fees) | High (Software Maint.) | Medium (Infrastructure) |
+| Sovereignty | Low (Data on MS Servers) | High (Owned Hardware) | High (Owned Hardware) |
+
+## 6. Strategic Recommendation
+
+The Stevedores organization should adopt the **Hybrid Architecture**:
+
+- **Do not** pay for GitHub Enterprise; its limitations on binary storage and environment management will stifle AI innovation.
+- **Do not** build a web UI from scratch; use commodity forge software to solve the hosting problem.
+- **Invest heavily** in the `aivcs` + `gitoxide` + `Attic` toolchain.
+
+This strategy delivers sovereignty, velocity via Rust-based tooling, and reliability via hermetic, reproducible AI environments. By treating the AI agent as a unified package of code, environment, and data, Stevedores constructs a development forge that is not just a repository, but a force multiplier for intelligence.


### PR DESCRIPTION
## Summary
- Moves the architecture rationale document from issue #49 into `docs/vision.md`
- Issue #49 closed as `not-planned` — it was a strategic document, not an actionable work item

## Test plan
- [ ] Markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)