### PR TITLE
feat(oxidized-state): CI run + diagnostics SurrealDB records

### DIFF
--- a/crates/oxidized-state/src/ci/ci_run_record.rs
+++ b/crates/oxidized-state/src/ci/ci_run_record.rs
@@ -1,0 +1,157 @@
+//! CI run record for SurrealDB persistence.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::surreal_dt;
+use super::surreal_dt_opt;
+
+/// CI run record stored in SurrealDB.
+///
+/// Mirrors the domain `CIRunSpec` + `CIResult` but uses string/JSON
+/// types suitable for SurrealDB storage (Layer 0 cannot depend on Layer 1).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CIRunRecord {
+    /// SurrealDB record ID.
+    pub id: Option<surrealdb::sql::Thing>,
+
+    /// Unique CI run ID (UUID string).
+    pub ci_run_id: String,
+
+    /// SHA256 hex digest of the run spec.
+    pub spec_digest: String,
+
+    /// Git commit SHA for this run.
+    pub git_sha: String,
+
+    /// What triggered this run: "manual", "pre_merge", "post_commit", "scheduled".
+    pub trigger: String,
+
+    /// JSON array of stage names.
+    pub stages: serde_json::Value,
+
+    /// Run status: "pending", "running", "passed", "failed", "cancelled".
+    pub status: String,
+
+    /// Total wall-clock duration in milliseconds.
+    pub total_duration_ms: u64,
+
+    /// Total number of diagnostics produced.
+    pub diagnostics_count: u32,
+
+    /// Number of stages that passed.
+    pub passed: u32,
+
+    /// Number of stages that failed.
+    pub failed: u32,
+
+    /// When the run was created.
+    #[serde(with = "surreal_dt")]
+    pub created_at: DateTime<Utc>,
+
+    /// When the run finished (None if still running).
+    #[serde(default, with = "surreal_dt_opt")]
+    pub finished_at: Option<DateTime<Utc>>,
+}
+
+impl CIRunRecord {
+    /// Create a new CI run record in "pending" state.
+    pub fn new(
+        ci_run_id: String,
+        spec_digest: String,
+        git_sha: String,
+        trigger: String,
+        stages: Vec<String>,
+    ) -> Self {
+        Self {
+            id: None,
+            ci_run_id,
+            spec_digest,
+            git_sha,
+            trigger,
+            stages: serde_json::json!(stages),
+            status: "pending".to_string(),
+            total_duration_ms: 0,
+            diagnostics_count: 0,
+            passed: 0,
+            failed: 0,
+            created_at: Utc::now(),
+            finished_at: None,
+        }
+    }
+
+    /// Mark run as passed.
+    pub fn pass(mut self, total_duration_ms: u64, passed: u32) -> Self {
+        self.status = "passed".to_string();
+        self.total_duration_ms = total_duration_ms;
+        self.passed = passed;
+        self.finished_at = Some(Utc::now());
+        self
+    }
+
+    /// Mark run as failed.
+    pub fn fail(mut self, total_duration_ms: u64, passed: u32, failed: u32) -> Self {
+        self.status = "failed".to_string();
+        self.total_duration_ms = total_duration_ms;
+        self.passed = passed;
+        self.failed = failed;
+        self.finished_at = Some(Utc::now());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ci_run_record_new() {
+        let record = CIRunRecord::new(
+            "run-123".to_string(),
+            "spec-abc".to_string(),
+            "sha-def".to_string(),
+            "manual".to_string(),
+            vec!["fmt".to_string(), "test".to_string()],
+        );
+
+        assert_eq!(record.ci_run_id, "run-123");
+        assert_eq!(record.status, "pending");
+        assert_eq!(record.total_duration_ms, 0);
+        assert_eq!(record.diagnostics_count, 0);
+        assert!(record.finished_at.is_none());
+    }
+
+    #[test]
+    fn test_ci_run_record_pass() {
+        let record = CIRunRecord::new(
+            "run-123".to_string(),
+            "spec-abc".to_string(),
+            "sha-def".to_string(),
+            "pre_merge".to_string(),
+            vec!["fmt".to_string()],
+        )
+        .pass(5000, 3);
+
+        assert_eq!(record.status, "passed");
+        assert_eq!(record.total_duration_ms, 5000);
+        assert_eq!(record.passed, 3);
+        assert!(record.finished_at.is_some());
+    }
+
+    #[test]
+    fn test_ci_run_record_fail() {
+        let record = CIRunRecord::new(
+            "run-456".to_string(),
+            "spec-xyz".to_string(),
+            "sha-789".to_string(),
+            "post_commit".to_string(),
+            vec!["clippy".to_string()],
+        )
+        .fail(3000, 2, 1);
+
+        assert_eq!(record.status, "failed");
+        assert_eq!(record.passed, 2);
+        assert_eq!(record.failed, 1);
+        assert!(record.finished_at.is_some());
+    }
+}

--- a/crates/oxidized-state/src/ci/diagnostics_record.rs
+++ b/crates/oxidized-state/src/ci/diagnostics_record.rs
@@ -1,0 +1,125 @@
+//! Diagnostics record for SurrealDB persistence.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::surreal_dt;
+
+/// A single diagnostic record stored in SurrealDB.
+///
+/// One record per diagnostic entry, linked to a CI run and stage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiagnosticsRecord {
+    /// SurrealDB record ID.
+    pub id: Option<surrealdb::sql::Thing>,
+
+    /// CI run ID this diagnostic belongs to.
+    pub ci_run_id: String,
+
+    /// Stage that produced this diagnostic (e.g. "clippy", "test").
+    pub stage: String,
+
+    /// Severity: "hint", "warning", "error".
+    pub severity: String,
+
+    /// Diagnostic/lint code (e.g. "clippy::needless_return").
+    pub code: Option<String>,
+
+    /// Human-readable message.
+    pub message: String,
+
+    /// Source file path.
+    pub file: Option<String>,
+
+    /// Line number.
+    pub line: Option<u32>,
+
+    /// Column number.
+    pub column: Option<u32>,
+
+    /// Source tool: "rustc", "clippy", "fmt", "test", "custom".
+    pub source: String,
+
+    /// When this diagnostic was recorded.
+    #[serde(with = "surreal_dt")]
+    pub created_at: DateTime<Utc>,
+}
+
+impl DiagnosticsRecord {
+    /// Create a new diagnostics record.
+    pub fn new(
+        ci_run_id: String,
+        stage: String,
+        severity: String,
+        message: String,
+        source: String,
+    ) -> Self {
+        Self {
+            id: None,
+            ci_run_id,
+            stage,
+            severity,
+            code: None,
+            message,
+            file: None,
+            line: None,
+            column: None,
+            source,
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Set file location.
+    pub fn with_location(mut self, file: String, line: u32, column: u32) -> Self {
+        self.file = Some(file);
+        self.line = Some(line);
+        self.column = Some(column);
+        self
+    }
+
+    /// Set diagnostic code.
+    pub fn with_code(mut self, code: String) -> Self {
+        self.code = Some(code);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_diagnostics_record_new() {
+        let record = DiagnosticsRecord::new(
+            "run-123".to_string(),
+            "clippy".to_string(),
+            "warning".to_string(),
+            "unused variable".to_string(),
+            "clippy".to_string(),
+        );
+
+        assert_eq!(record.ci_run_id, "run-123");
+        assert_eq!(record.stage, "clippy");
+        assert_eq!(record.severity, "warning");
+        assert!(record.code.is_none());
+        assert!(record.file.is_none());
+    }
+
+    #[test]
+    fn test_diagnostics_record_with_location() {
+        let record = DiagnosticsRecord::new(
+            "run-123".to_string(),
+            "rustc".to_string(),
+            "error".to_string(),
+            "cannot find value".to_string(),
+            "rustc".to_string(),
+        )
+        .with_location("src/main.rs".to_string(), 42, 9)
+        .with_code("E0425".to_string());
+
+        assert_eq!(record.file, Some("src/main.rs".to_string()));
+        assert_eq!(record.line, Some(42));
+        assert_eq!(record.column, Some(9));
+        assert_eq!(record.code, Some("E0425".to_string()));
+    }
+}

--- a/crates/oxidized-state/src/ci/mod.rs
+++ b/crates/oxidized-state/src/ci/mod.rs
@@ -1,0 +1,61 @@
+//! CI-specific SurrealDB records for the AIVCS CI engine.
+//!
+//! These records store CI run metadata and diagnostics in SurrealDB,
+//! following the same patterns as `RunRecord` and `RunEventRecord`.
+
+pub mod ci_run_record;
+pub mod diagnostics_record;
+
+pub use ci_run_record::CIRunRecord;
+pub use diagnostics_record::DiagnosticsRecord;
+
+/// Module for serializing chrono DateTime to SurrealDB datetime format.
+pub(crate) mod surreal_dt {
+    use chrono::{DateTime, Utc};
+    use serde::{self, Deserialize, Deserializer, Serializer};
+    use surrealdb::sql::Datetime as SurrealDatetime;
+
+    pub fn serialize<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let sd = SurrealDatetime::from(*date);
+        serde::Serialize::serialize(&sd, serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let sd = SurrealDatetime::deserialize(deserializer)?;
+        Ok(DateTime::from(sd))
+    }
+}
+
+/// Module for serializing optional chrono DateTime to SurrealDB datetime format.
+pub(crate) mod surreal_dt_opt {
+    use chrono::{DateTime, Utc};
+    use serde::{self, Deserialize, Deserializer, Serializer};
+    use surrealdb::sql::Datetime as SurrealDatetime;
+
+    pub fn serialize<S>(date: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match date {
+            Some(d) => {
+                let sd = SurrealDatetime::from(*d);
+                serde::Serialize::serialize(&Some(sd), serializer)
+            }
+            None => serde::Serialize::serialize(&None::<SurrealDatetime>, serializer),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let sd = Option::<SurrealDatetime>::deserialize(deserializer)?;
+        Ok(sd.map(DateTime::from))
+    }
+}

--- a/crates/oxidized-state/src/lib.rs
+++ b/crates/oxidized-state/src/lib.rs
@@ -17,6 +17,7 @@
 //! - `ReleaseRecordSchema`: Schema for release management
 //! - `init_schema`: Initialize all tables with constraints and indexes
 
+pub mod ci;
 mod error;
 pub mod fakes;
 mod handle;


### PR DESCRIPTION
## Summary
- Add `oxidized-state/src/ci/` module with SurrealDB records for CI persistence
- `CIRunRecord` with pending/pass/fail state transitions, stage counts, timing
- `DiagnosticsRecord` with location builder pattern, code, severity
- Local surreal_datetime helpers (avoids touching existing schema.rs)

## Test plan
- [x] 5 co-located tests: constructor, pass/fail transitions, location builder
- [x] `cargo clippy -p oxidized-state -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean

Refs #98 Story 1.2
Part of: #96, #97, #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)