### PR TITLE
ci: surface local-ci results as artifacts and summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,41 @@ jobs:
         run: echo "$HOME/go/bin" >> "$GITHUB_PATH"
 
       - name: Run local-ci
-        run: local-ci --json
+        id: local_ci
+        run: |
+          set +e
+          set -o pipefail
+          local-ci --json | tee local-ci-report.json
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Upload local-ci report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: local-ci-report
+          path: local-ci-report.json
+          retention-days: 30
+
+      - name: Summarize results
+        if: always()
+        run: |
+          if [ ! -f local-ci-report.json ]; then exit 0; fi
+          passed=$(jq '.passed' local-ci-report.json)
+          failed=$(jq '.failed' local-ci-report.json)
+          duration=$(jq '.duration_ms' local-ci-report.json)
+          echo "### local-ci: ${passed} passed, ${failed} failed (${duration}ms)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Stage | Status | Duration | Cache |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|--------|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          jq -r '.results[] | "| \(.name) | \(.status) | \(.duration_ms)ms | \(.cache_hit) |"' \
+            local-ci-report.json >> "$GITHUB_STEP_SUMMARY"
+          # Annotate failures
+          jq -r '.results[] | select(.status == "fail") | "::error title=local-ci: \(.name) failed::\(.error // .output // "unknown error" | .[0:200])"' \
+            local-ci-report.json
+
+      - name: Enforce gate
+        if: always()
+        run: exit ${{ steps.local_ci.outputs.exit_code }}
 
   nix-report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Replace bare `local-ci --json` step with capture+surface pattern
- Upload JSON report as artifact (30-day retention) for debugging
- Parse results into GitHub Step Summary with markdown table (stage, status, duration, cache hit)
- Emit `::error::` annotations for failed stages for inline PR feedback
- Use `set -o pipefail` to correctly capture local-ci exit code through `tee`

## Test plan
- [ ] Push to branch, verify Actions tab shows artifact upload step
- [ ] Verify step summary renders markdown table with stage results
- [ ] Introduce a deliberate failure (e.g. clippy warning) and verify `::error::` annotation appears
- [ ] Confirm workflow still fails on local-ci failure (gate enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)