### PR TITLE
chore: prune stale feature branches

### DIFF
--- a/docs/BRANCH_CLEANUP.md
+++ b/docs/BRANCH_CLEANUP.md
@@ -1,0 +1,33 @@
+# Branch Cleanup Record
+
+## Deleted Branches
+
+### claude-code series (removed)
+- claude-code/ci-diagnostics-parser
+- claude-code/ci-domain-types
+- claude-code/ci-gate-rules
+- claude-code/ci-repair-planner
+- claude-code/ci-results-surfacing
+- claude-code/ci-runner-trait
+- claude-code/ci-storage-records
+- claude-code/epic-0-envelope
+- claude-code/epic-1-ci-domain
+- claude-code/epic-3-runner
+- claude-code/epic-4-events
+
+### codex series (removed)
+- codex/featAIVCS-M4B
+- codex/featAIVCS-M4C-followup
+- codex/featureCiPersistenceRecords
+- codex/featureLocalCiChecks
+
+## Retained Branches
+
+- main (primary branch)
+- develop (development branch)
+
+## Rationale
+
+Removed stale feature and epic branches that have been integrated into develop/main.
+These branches were from completed work items and are no longer needed.
+


### PR DESCRIPTION
## Summary

Removes 15 stale feature and epic branches that have been integrated into main/develop:

### Deleted Branches

**claude-code series (11 branches):**
- claude-code/ci-diagnostics-parser
- claude-code/ci-domain-types
- claude-code/ci-gate-rules
- claude-code/ci-repair-planner
- claude-code/ci-results-surfacing
- claude-code/ci-runner-trait
- claude-code/ci-storage-records
- claude-code/epic-0-envelope
- claude-code/epic-1-ci-domain
- claude-code/epic-3-runner
- claude-code/epic-4-events

**codex series (4 branches):**
- codex/featAIVCS-M4B
- codex/featAIVCS-M4C-followup
- codex/featureCiPersistenceRecords
- codex/featureLocalCiChecks

### Retained Branches

- `main` - primary release branch
- `develop` - development integration branch

## Rationale

These branches represent completed work from earlier development phases and have been fully integrated into the main development branches. Removing them improves repository maintainability and reduces branch clutter.

## Test Plan

- [x] Repository compiles successfully
- [x] All branches have been merged/integrated into develop
- [x] Only main and develop branches remain in primary workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)