### PR TITLE
docs: add start-contributing and CODEX guides

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,60 @@
+# CODEX.md
+
+Operating instructions for AI/code agents working in this repository.
+
+## Scope
+
+- Applies to the full workspace.
+- Prefer focused, minimal diffs per PR.
+
+## Branch and PR Rules
+
+- Base branch: `develop`.
+- Create feature branches from `develop`.
+- Keep PRs scoped to a single change theme.
+
+## Read First
+
+- `README.md`
+- `CONTRIBUTING.md`
+- `docs/architecture.md`
+- `docs/runbooks/local-development.md`
+- `docs/runbooks/ci-troubleshooting.md`
+
+## Module Ownership Map
+
+- Core domain/orchestration: `crates/aivcs-core/src/domain/*`, `crates/aivcs-core/src/lib.rs`
+- Replay/diff/telemetry: `crates/aivcs-core/src/replay.rs`, `crates/aivcs-core/src/diff/*`, `crates/aivcs-core/src/obs.rs`, `crates/aivcs-core/src/telemetry.rs`
+- CI/pipeline/gates: `crates/aivcs-ci/src/*`, `crates/aivcs-core/src/gate.rs`, `crates/aivcs-core/src/publish_gate.rs`
+- Storage backend: `crates/oxidized-state/src/*`
+- Env manager: `crates/nix-env-manager/src/*`
+- Semantic merge: `crates/semantic-rag-merge/src/lib.rs`
+- CLI/daemon: `crates/aivcs-cli/src/main.rs`, `crates/aivcsd/src/main.rs`
+
+## Coding Expectations
+
+- Preserve public behavior unless the PR explicitly changes contract.
+- Prefer explicit errors over silent fallback.
+- Avoid unrelated refactors.
+
+## Validation
+
+Run at minimum:
+
+```bash
+cargo test --all
+```
+
+If touching style/lints and feasible:
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features
+```
+
+## PR Checklist
+
+- State problem and approach clearly.
+- Include test evidence.
+- Call out compatibility and risk impacts.
+- Keep changes aligned with module ownership map.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to AIVCS
+
+This is a practical map for contributors who want to make focused, high-value changes quickly.
+
+## Local Setup
+
+```bash
+git clone https://github.com/stevedores-org/aivcs.git
+cd aivcs
+cargo test --all
+```
+
+## Start Contributing Map
+
+### 1) Core domain and orchestration
+- Primary files: `crates/aivcs-core/src/domain/*`, `crates/aivcs-core/src/lib.rs`
+- Use this area for snapshot/run/release models, domain invariants, and orchestration behavior.
+
+### 2) Diff, replay, and observability flows
+- Primary files: `crates/aivcs-core/src/diff/*`, `crates/aivcs-core/src/replay.rs`, `crates/aivcs-core/src/obs.rs`, `crates/aivcs-core/src/telemetry.rs`
+- Tests: `crates/aivcs-core/tests/*`
+- Use this area for change tracking, run replay correctness, and runtime instrumentation.
+
+### 3) CI/gates/promotion pipeline logic
+- Primary files: `crates/aivcs-ci/src/*`, `crates/aivcs-core/src/gate.rs`, `crates/aivcs-core/src/publish_gate.rs`, `crates/aivcs-core/src/deploy*`
+- Tests: `crates/aivcs-ci/tests/pipeline_integration.rs`, `crates/aivcs-core/tests/merge_gate.rs`, `crates/aivcs-core/tests/publish_gate.rs`
+- Use this area for verification stages, promotion checks, and release gating semantics.
+
+### 4) Storage and state backend
+- Primary files: `crates/oxidized-state/src/*`
+- Tests: `crates/oxidized-state/tests/*`
+- Use this area for schema, handles, storage traits, SurrealDB interactions, and migration behavior.
+
+### 5) Environment and reproducibility tooling
+- Primary files: `crates/nix-env-manager/src/*`
+- Use this area for flake hashing, logic hashing, and Attic/cache integration.
+
+### 6) Semantic merge and RAG behavior
+- Primary files: `crates/semantic-rag-merge/src/lib.rs`
+- Use this area for memory diff/merge logic and conflict resolution behavior.
+
+### 7) User-facing surfaces (CLI and daemon)
+- CLI: `crates/aivcs-cli/src/main.rs`
+- Daemon: `crates/aivcsd/src/main.rs`
+- Use this area for command ergonomics and API/daemon entrypoints.
+
+### 8) Docs and runbooks
+- Primary files: `README.md`, `docs/*.md`, `docs/runbooks/*.md`
+- Keep docs aligned with implemented behavior and command outputs.
+
+## Workflow
+
+1. Branch from `develop`.
+2. Keep one change theme per PR.
+3. Add/update tests for behavior changes.
+4. Run:
+
+```bash
+cargo test --all
+```
+
+5. Open PR to `develop` with:
+- problem statement
+- approach and design notes
+- test evidence
+- compatibility/risk notes
+
+## Review Expectations
+
+- Correctness before optimization.
+- Explicit error semantics (avoid silent fallback in core paths).
+- Compatibility impact called out when behavior changes.
+- Tests cover happy path and key failure modes.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ aivcs trace experiment-0 --depth 50
 - [Database Configuration](docs/runbooks/database-configuration.md) — in-memory, local, cloud setup
 - [CI Troubleshooting](docs/runbooks/ci-troubleshooting.md) — common failures, reproduce locally
 
+## Contributing
+
+- Start here: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Agent/operator workflow rules: [CODEX.md](CODEX.md)
+
 ## Crate Structure
 
 - **aivcs-core**: Main CLI and orchestration logic


### PR DESCRIPTION
## Summary
- add `CONTRIBUTING.md` with a task-oriented start-contributing map
- add `CODEX.md` with agent/operator workflow rules
- add README links to both docs under a new Contributing section

## Why
Contributors and coding agents need a fast mapping from intent to relevant crates/files. This improves onboarding speed and keeps PRs scoped.

## Validation
- `cargo test --all` (workspace tests all passing)
