### PR TITLE
fix: add nix-cache trusted public key to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   nixConfig = {
     extra-substituters = [ "https://nix-cache.stevedores.org/stevedores" ];
     extra-trusted-substituters = [ "https://nix-cache.stevedores.org/stevedores" ];
+    extra-trusted-public-keys = [ "stevedores-cache-1:bXLxkipycRWproIJnk8pPWNFdgVfeV+I2mJXCoW4/ag=" ];
   };
 
   # NOTE: Inputs are pinned to exact commits via flake.lock (committed to repo).


### PR DESCRIPTION
Closes stevedores-org/nix-cache#10

Adds the trusted public key for nix-cache.stevedores.org to the flake.nix nixConfig section, enabling proper verification of cached packages.