### PR TITLE
fix: trust current stevedores-1 cache signing key

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,12 @@
 
   nixConfig = {
     extra-substituters = [ "https://nix-cache.stevedores.org" ];
-    extra-trusted-public-keys = [ "stevedores-cache-1:bXLxkipycRWproIJnk8pPWNFdgVfeV+I2mJXCoW4/ag=" ];
+    extra-trusted-public-keys = [
+      "stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A="
+      # Legacy key — kept trusted for any artifacts already pushed under
+      # this name. Can be removed once the cache is re-signed under stevedores-1.
+      "stevedores-cache-1:bXLxkipycRWproIJnk8pPWNFdgVfeV+I2mJXCoW4/ag="
+    ];
   };
 
   # NOTE: Inputs are pinned to exact commits via flake.lock (committed to repo).


### PR DESCRIPTION
## Summary
- Adds the current `stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A=` public key to `nixConfig.extra-trusted-public-keys`.
- Keeps the legacy `stevedores-cache-1:bXLxkipycRWproIJnk8pPWNFdgVfeV+I2mJXCoW4/ag=` key alongside it (with a comment) so previously-signed artifacts remain trusted.
- Layout mirrors `lornu-ai/lornu.ai`'s `flake.nix`.

## Why
PR #182 only added the legacy key. Without `stevedores-1`, Nix silently ignores any substituter response signed under the current key — cache is effectively dead for new artifacts.

## Test plan
- [ ] CI green (`rust-checks`, `nix-report`)
- [ ] After merge, re-run CI on PR #185 (develop → main) so main picks up both keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)