### PR TITLE
fix(nix): include .github/workflows in test source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,9 +37,19 @@
 
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
+        # Source filter: cargo sources plus .github/workflows/ so that
+        # workflow-validation tests (aivcs-core::eval_workflow,
+        # aivcs-core::ci_workflow) can read the YAML files at test time.
+        src = pkgs.lib.cleanSourceWith {
+          src = ./.;
+          filter = path: type:
+            (craneLib.filterCargoSources path type)
+            || (pkgs.lib.hasInfix "/.github/workflows/" (toString path));
+        };
+
         # Common args for crane builds
         commonArgs = {
-          src = craneLib.cleanCargoSource ./.;
+          inherit src;
           strictDeps = true;
           buildInputs = with pkgs; [
             openssl
@@ -71,7 +81,7 @@
           });
 
           fmt = craneLib.cargoFmt {
-            src = craneLib.cleanCargoSource ./.;
+            inherit src;
           };
 
           tests = craneLib.cargoNextest (commonArgs // {

--- a/flake.nix
+++ b/flake.nix
@@ -37,10 +37,15 @@
 
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
-        # Source filter: cargo sources plus .github/workflows/ so that
+        # Narrow source for cargo work (build, clippy, fmt, dep cache). Keeping
+        # this filter unchanged means buildDepsOnly's cache is not invalidated
+        # by edits to .github/workflows/*.yml.
+        cargoSrc = craneLib.cleanCargoSource ./.;
+
+        # Wider source for tests only: cargo sources plus .github/workflows/ so
         # workflow-validation tests (aivcs-core::eval_workflow,
         # aivcs-core::ci_workflow) can read the YAML files at test time.
-        src = pkgs.lib.cleanSourceWith {
+        testSrc = pkgs.lib.cleanSourceWith {
           src = ./.;
           filter = path: type:
             (craneLib.filterCargoSources path type)
@@ -49,7 +54,7 @@
 
         # Common args for crane builds
         commonArgs = {
-          inherit src;
+          src = cargoSrc;
           strictDeps = true;
           buildInputs = with pkgs; [
             openssl
@@ -81,10 +86,11 @@
           });
 
           fmt = craneLib.cargoFmt {
-            inherit src;
+            src = cargoSrc;
           };
 
           tests = craneLib.cargoNextest (commonArgs // {
+            src = testSrc;
             inherit cargoArtifacts;
             partitions = 1;
             partitionType = "count";


### PR DESCRIPTION
## Summary

`craneLib.cleanCargoSource` strips `.github/` from the Nix build sandbox, so workflow-validation tests (`aivcs-core::eval_workflow`, `aivcs-core::ci_workflow`) fail under `nix flake check` despite passing under `cargo nextest` in `rust-checks`.

Replace the cargo-only source with a `cleanSourceWith` filter that keeps both cargo sources and `.github/workflows/` YAML so the validation tests can read the files at test time.

## Why now

`nix-checks` is currently red on the `develop → main` merge PR (#185) with exactly this failure (11 workflow-validation tests panic on missing file). Same failure mode I saw earlier on #183.

## Test plan

- [x] `nix eval .#checks.x86_64-linux.tests.drvPath` evaluates without error
- [ ] CI: `nix-checks` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)