### PR TITLE
fix(nix): skip duplicate test run in workspace build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,9 +71,14 @@
         # Build workspace deps first (for caching)
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
-        # Build the full workspace
+        # Build the full workspace. Tests are run separately by the `tests`
+        # check (cargoNextest with `testSrc` that includes .github/workflows/);
+        # disabling `doCheck` here avoids a duplicate `cargo test` against
+        # `cargoSrc`, which lacks the workflow YAML files and would fail the
+        # workflow-validation tests.
         workspace = craneLib.buildPackage (commonArgs // {
           inherit cargoArtifacts;
+          doCheck = false;
         });
       in
       {


### PR DESCRIPTION
## Summary

- `workspace = craneLib.buildPackage ...` runs `cargo test` against the narrow `cargoSrc`, which by design omits `.github/workflows/*.yml`
- Workflow-validation tests (`ci_workflow.rs`, `eval_workflow.rs`) read those files at test time and panic when they're missing
- PR #187 fixed the `tests` check (cargoNextest with `testSrc`) but the implicit `cargo test` in `buildPackage` still ran against `cargoSrc` and failed
- Set `doCheck = false` on `workspace` — tests are already covered by the separate `tests` check, so this only removes duplicate work

## Background

Run 25941680022 (post-#187) showed `cargoNextest` passing but `cargo-package` (the `buildPackage` derivation) failing on the same workflow-missing test:

```
cargo-package> test ci_workflow_has_concurrency_control ... FAILED
cargo-package> thread '...' panicked at crates/aivcs-core/tests/ci_workflow.rs:13:29:
cargo-package> failed to read /build/source/.github/workflows/ci.yml: No such file or directory
```

## Test plan

- [ ] Nix flake check passes on this PR
- [ ] `develop → main` release PR (#185) is unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)