### PR TITLE
fix(nix): include .github ancestor dirs in testSrc filter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,11 +45,19 @@
         # Wider source for tests only: cargo sources plus .github/workflows/ so
         # workflow-validation tests (aivcs-core::eval_workflow,
         # aivcs-core::ci_workflow) can read the YAML files at test time.
+        #
+        # cleanSourceWith requires every ancestor directory of an included file
+        # to also pass the filter, so the `.github` and `.github/workflows`
+        # dirs are matched explicitly — not just the YAML leaves.
         testSrc = pkgs.lib.cleanSourceWith {
           src = ./.;
           filter = path: type:
+            let p = toString path; in
             (craneLib.filterCargoSources path type)
-            || (pkgs.lib.hasInfix "/.github/workflows/" (toString path));
+            || (type == "directory" && (
+                 pkgs.lib.hasSuffix "/.github" p
+                 || pkgs.lib.hasSuffix "/.github/workflows" p))
+            || (pkgs.lib.hasInfix "/.github/workflows/" p);
         };
 
         # Common args for crane builds


### PR DESCRIPTION
## Summary

The \`testSrc\` filter in \`flake.nix\` intended to include \`.github/workflows/*.yml\` so the workflow-validation tests (\`aivcs-core::ci_workflow\`, \`aivcs-core::eval_workflow\`) can read them at test time. But it only matched the leaf YAML paths, not the ancestor directories.

\`lib.cleanSourceWith\` requires every ancestor directory of an included file to also pass the filter. Result: the leaf-only filter caused the entire \`.github\` tree to be stripped from the source, and 11 workflow tests failed with file-not-found inside the Nix sandbox.

## Fix

Extend the filter to explicitly match the \`.github\` and \`.github/workflows\` directories so the YAML files actually land in the test source tree.

## Why develop is currently red

This bug entered develop with the nix CI overhaul (PR #181) and has been failing every \`nix-checks\` run on develop since 2026-05-14. PR #185 (develop → main) is blocked behind it.

## Test plan

- [ ] CI \`nix-checks\` goes green (the 11 \`workflow_*\` tests pass)
- [ ] CI \`rust-checks\` stays green (no impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)