### PR TITLE
fix(nix): include .github/workflows YAMLs in sandbox source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,22 +42,28 @@
         # by edits to .github/workflows/*.yml.
         cargoSrc = craneLib.cleanCargoSource ./.;
 
-        # Wider source for tests only: cargo sources plus .github/workflows/ so
-        # workflow-validation tests (aivcs-core::eval_workflow,
-        # aivcs-core::ci_workflow) can read the YAML files at test time.
+        # Wider source for tests only: cargo sources plus .github/workflows/*.yml
+        # so the workflow-validation tests in crates/aivcs-core
+        # (eval_workflow.rs, ci_workflow.rs) can read those YAMLs at runtime.
+        # Without this, those tests panic inside the nix sandbox.
         #
         # cleanSourceWith requires every ancestor directory of an included file
         # to also pass the filter, so the `.github` and `.github/workflows`
-        # dirs are matched explicitly — not just the YAML leaves.
+        # dirs are matched explicitly — not just the YAML leaves. The leaf
+        # match restricts to regular `.yml` files so the filter never picks up
+        # symlinks, sockets, or stray `.yaml`/swap files in that path.
         testSrc = pkgs.lib.cleanSourceWith {
           src = ./.;
+          name = "test-source";
           filter = path: type:
             let p = toString path; in
             (craneLib.filterCargoSources path type)
-            || (type == "directory" && (
-                 pkgs.lib.hasSuffix "/.github" p
-                 || pkgs.lib.hasSuffix "/.github/workflows" p))
-            || (pkgs.lib.hasInfix "/.github/workflows/" p);
+            || (type == "directory"
+                && (pkgs.lib.hasSuffix "/.github" p
+                    || pkgs.lib.hasSuffix "/.github/workflows" p))
+            || (type == "regular"
+                && pkgs.lib.hasInfix "/.github/workflows/" p
+                && pkgs.lib.hasSuffix ".yml" p);
         };
 
         # Common args for crane builds


### PR DESCRIPTION
## Summary
- Fixes the 11 failing `nix-checks` tests blocking PR #185 (`develop` → `main`).
- `craneLib.cleanCargoSource ./.` was stripping `.github/workflows/*.yml` from the sandbox source, so tests in `crates/aivcs-core/tests/{eval_workflow,ci_workflow}.rs` panicked with *"failed to read …/aivcs-eval.yml: No such file or directory"* under `nix flake check` while still passing under plain `cargo test` (which is why `rust-checks` stayed green).
- Extends the source filter to keep everything `filterCargoSources` keeps **plus** any `.yml` under `.github/workflows/`. The `fmt` check keeps the narrower filter since it only needs Rust sources.

## Failing tests addressed
- `aivcs-core::ci_workflow::ci_workflow_has_concurrency_control`
- `aivcs-core::eval_workflow::*` (10 tests)

## Test plan
- [ ] `nix flake check` (or the `nix-checks` GH workflow) passes on this branch
- [ ] `rust-checks` still passes
- [ ] After merge, re-run checks on #185 to unblock the develop → main merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)