### PR TITLE
test(github): cover RELIC_LIBRARIAN_USERNAME validation and document pr-open

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ echo '{"step": 1, "memory": "learned X"}' > state.json
 | `trace` | Time-travel debugging - show reasoning trace |
 | `replay` | Replay a recorded run artifact by run ID |
 | `diff-runs` | Diff the tool-call sequences of two runs |
+| `pr open` | Open a GitHub Pull Request and request review from the Librarian Agent |
 
 ### Environment Commands (Phase 2)
 
@@ -146,6 +147,31 @@ The JSON-RPC params contain the AIVCS commit hash. Snapshot events include the s
   }
 }
 ```
+
+### GitHub Integration (`pr open`)
+
+`aivcs pr open` creates a Pull Request via the GitHub API and, by default, requests review from the Librarian Agent so it can audit changes before downstream OCI builds. This is the canonical PR-creation path used by autonomous builder agents running in ephemeral ADK Jobs.
+
+```bash
+export GITHUB_TOKEN="<github-app-installation-token-or-pat>"
+export RELIC_LIBRARIAN_USERNAME="librarian-bot"
+aivcs pr open \
+  --owner stevedores-org \
+  --repo aivcs \
+  --head feature/my-change \
+  --base main \
+  --title "feat: my change" \
+  --body  "Summary of what changed."
+```
+
+Required environment:
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_TOKEN` | Bearer token for the GitHub API. Accepts a GitHub App installation token (preferred for autonomous Jobs) or a personal access token. |
+| `RELIC_LIBRARIAN_USERNAME` | GitHub username of the Librarian Agent. Required when `--librarian` is enabled (the default). Missing or whitespace-only values are rejected eagerly so the failure surfaces before the API call rather than mid-pipeline. |
+
+The `--librarian` flag defaults to `true`; pass `--librarian=false` to skip the review request in development or test contexts where the Librarian is not deployed.
 
 ## Documentation
 

--- a/crates/aivcs-core/src/github.rs
+++ b/crates/aivcs-core/src/github.rs
@@ -134,12 +134,7 @@ impl GitHubClient {
     /// API call, rather than silently requesting review from a placeholder user
     /// that may not exist and failing partway through a multi-step pipeline.
     pub async fn request_librarian_review(&self, pr_number: u64) -> Result<()> {
-        let librarian = std::env::var("RELIC_LIBRARIAN_USERNAME")
-            .context("RELIC_LIBRARIAN_USERNAME must be set to request a Librarian Agent review")?;
-        anyhow::ensure!(
-            !librarian.trim().is_empty(),
-            "RELIC_LIBRARIAN_USERNAME is set but empty"
-        );
+        let librarian = resolve_librarian_username(std::env::var("RELIC_LIBRARIAN_USERNAME"))?;
 
         info!(
             "Requesting review from Librarian Agent ('{}') on PR #{}",
@@ -154,5 +149,74 @@ impl GitHubClient {
             .context(format!("failed to request review for PR #{}", pr_number))?;
 
         Ok(())
+    }
+}
+
+/// Validate the raw `RELIC_LIBRARIAN_USERNAME` env-var lookup result.
+///
+/// Split out so the validation contract can be unit-tested without an HTTP
+/// client. A missing or whitespace-only value is rejected eagerly: the
+/// alternative is silently requesting review from a placeholder user that may
+/// not exist and failing partway through a multi-step pipeline.
+fn resolve_librarian_username(
+    raw: std::result::Result<String, std::env::VarError>,
+) -> Result<String> {
+    let value =
+        raw.context("RELIC_LIBRARIAN_USERNAME must be set to request a Librarian Agent review")?;
+    anyhow::ensure!(
+        !value.trim().is_empty(),
+        "RELIC_LIBRARIAN_USERNAME is set but empty"
+    );
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env::VarError;
+
+    #[test]
+    fn resolve_librarian_username_missing_env_is_rejected() {
+        let err = resolve_librarian_username(Err(VarError::NotPresent)).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("RELIC_LIBRARIAN_USERNAME must be set"),
+            "expected missing-env error, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn resolve_librarian_username_empty_string_is_rejected() {
+        let err = resolve_librarian_username(Ok(String::new())).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("set but empty"),
+            "expected empty-value error, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn resolve_librarian_username_whitespace_only_is_rejected() {
+        let err = resolve_librarian_username(Ok("   \t\n".to_string())).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("set but empty"),
+            "expected whitespace-only to be treated as empty, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn resolve_librarian_username_valid_value_is_returned_verbatim() {
+        let username = resolve_librarian_username(Ok("librarian-bot".to_string())).unwrap();
+        assert_eq!(username, "librarian-bot");
+    }
+
+    #[test]
+    fn resolve_librarian_username_not_unicode_is_rejected() {
+        let err = resolve_librarian_username(Err(VarError::NotUnicode(std::ffi::OsString::from(
+            "ignored",
+        ))))
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("RELIC_LIBRARIAN_USERNAME must be set"),
+            "expected missing-env-style error for non-unicode value, got: {err:#}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Split `RELIC_LIBRARIAN_USERNAME` validation out of `GitHubClient::request_librarian_review` into a pure helper (`resolve_librarian_username`) so the contract is unit-testable without an HTTP client.
- Add five unit tests covering missing / empty / whitespace-only / non-unicode / happy-path inputs, pinning the eager-fail behavior so a future refactor can't silently regress to requesting review from a placeholder user mid-pipeline.
- Add a "GitHub Integration (`pr open`)" section to the README documenting `GITHUB_TOKEN`, `RELIC_LIBRARIAN_USERNAME`, and the `--librarian=true` default; list `pr open` in the commands table.

## Why

`stevedores-org/aivcs#191` (Epic 2 — Zero-Touch PR pipeline) requires "PRs opened by aivcs automatically request review from the Librarian Agent." That behavior is already implemented in `GitHubClient::open_pr` + `request_librarian_review`, but until now it had **zero test coverage** and `RELIC_LIBRARIAN_USERNAME` was only mentioned inside `github.rs`. This PR moves that criterion from "implemented" to "implemented, tested, and discoverable" — no behavior change.

Refs #191. No-op for the public API surface — `request_librarian_review` keeps the same signature and same error messages.

## Test plan

- [x] `cargo test -p aivcs-core --lib github::` — all 5 new tests pass
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aivcs-core --lib --tests -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)