### PR TITLE
fix(github): distinct error message for RELIC_LIBRARIAN_USERNAME non-UTF-8

### DIFF
--- a/crates/aivcs-core/src/github.rs
+++ b/crates/aivcs-core/src/github.rs
@@ -161,8 +161,17 @@ impl GitHubClient {
 fn resolve_librarian_username(
     raw: std::result::Result<String, std::env::VarError>,
 ) -> Result<String> {
-    let value =
-        raw.context("RELIC_LIBRARIAN_USERNAME must be set to request a Librarian Agent review")?;
+    let value = match raw {
+        Ok(v) => v,
+        Err(std::env::VarError::NotPresent) => {
+            anyhow::bail!(
+                "RELIC_LIBRARIAN_USERNAME must be set to request a Librarian Agent review"
+            )
+        }
+        Err(std::env::VarError::NotUnicode(_)) => {
+            anyhow::bail!("RELIC_LIBRARIAN_USERNAME contains non-UTF-8 bytes")
+        }
+    };
     anyhow::ensure!(
         !value.trim().is_empty(),
         "RELIC_LIBRARIAN_USERNAME is set but empty"
@@ -209,14 +218,22 @@ mod tests {
     }
 
     #[test]
-    fn resolve_librarian_username_not_unicode_is_rejected() {
+    fn resolve_librarian_username_not_unicode_is_rejected_with_distinct_message() {
+        // NotUnicode means the env var IS set but contains invalid UTF-8 —
+        // distinguish it from "missing" so an operator debugging an ESO
+        // projection sees the real failure mode.
         let err = resolve_librarian_username(Err(VarError::NotUnicode(std::ffi::OsString::from(
             "ignored",
         ))))
         .unwrap_err();
+        let rendered = format!("{err:#}");
         assert!(
-            format!("{err:#}").contains("RELIC_LIBRARIAN_USERNAME must be set"),
-            "expected missing-env-style error for non-unicode value, got: {err:#}"
+            rendered.contains("non-UTF-8"),
+            "expected non-UTF-8-specific error, got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("must be set"),
+            "non-UTF-8 error must not claim the variable is unset, got: {rendered}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #201. Splits the `VarError` handling in `resolve_librarian_username` so `NotPresent` and `NotUnicode` emit distinct messages:

- `NotPresent` → `RELIC_LIBRARIAN_USERNAME must be set …` (unchanged)
- `NotUnicode` → `RELIC_LIBRARIAN_USERNAME contains non-UTF-8 bytes` (new)

## Why

`NotUnicode` means the variable *is* set but contains invalid UTF-8 — a real failure mode for ESO-projected secrets where the underlying Key Vault value was encoded incorrectly. Today the operator hitting that path sees "must be set" and chases the wrong thing. Surfacing the actual failure mode shortens the debug loop for the autonomous Job runtime targeted by Epic #191.

This is the exact "minor / non-blocking" item flagged during the review of #201. Filing as a separate small PR rather than amending so the history shows the fix landed independently.

## Test plan

- [x] `cargo test -p aivcs-core --lib github::` — all 5 tests still pass; the `NotUnicode` test now asserts the new wording *and* asserts the message does **not** contain `must be set` (pinning the disambiguation)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aivcs-core --lib --tests -- -D warnings`

Refs #191. Follow-up to #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)