### PR TITLE
feat(epic-191): restore CODE_COMMITTED emission and GitHub branch/commit CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ echo '{"step": 1, "memory": "learned X"}' > state.json
 | `trace` | Time-travel debugging - show reasoning trace |
 | `replay` | Replay a recorded run artifact by run ID |
 | `diff-runs` | Diff the tool-call sequences of two runs |
+| `pr open` | Open a GitHub Pull Request and request review from the Librarian Agent |
 
 ### Environment Commands (Phase 2)
 
@@ -146,6 +147,31 @@ The JSON-RPC params contain the AIVCS commit hash. Snapshot events include the s
   }
 }
 ```
+
+### GitHub Integration (`pr open`)
+
+`aivcs pr open` creates a Pull Request via the GitHub API and, by default, requests review from the Librarian Agent so it can audit changes before downstream OCI builds. This is the canonical PR-creation path used by autonomous builder agents running in ephemeral ADK Jobs.
+
+```bash
+export GITHUB_TOKEN="<github-app-installation-token-or-pat>"
+export RELIC_LIBRARIAN_USERNAME="librarian-bot"
+aivcs pr open \
+  --owner stevedores-org \
+  --repo aivcs \
+  --head feature/my-change \
+  --base main \
+  --title "feat: my change" \
+  --body  "Summary of what changed."
+```
+
+Required environment:
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_TOKEN` | Bearer token for the GitHub API. Accepts a GitHub App installation token (preferred for autonomous Jobs) or a personal access token. |
+| `RELIC_LIBRARIAN_USERNAME` | GitHub username of the Librarian Agent. Required when `--librarian` is enabled (the default). Missing or whitespace-only values are rejected eagerly so the failure surfaces before the API call rather than mid-pipeline. |
+
+The `--librarian` flag defaults to `true`; pass `--librarian=false` to skip the review request in development or test contexts where the Librarian is not deployed.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -148,13 +148,27 @@ The JSON-RPC params contain the AIVCS commit hash. Snapshot events include the s
 }
 ```
 
-### GitHub Integration (`pr open`)
+### GitHub Integration (`pr open`, `pr branch`, `pr commit`)
 
-`aivcs pr open` creates a Pull Request via the GitHub API and, by default, requests review from the Librarian Agent so it can audit changes before downstream OCI builds. This is the canonical PR-creation path used by autonomous builder agents running in ephemeral ADK Jobs.
+Autonomous builder agents use the `pr` subcommands to branch, commit, and open Pull Requests via the GitHub API. Tokens are read from `GITHUB_TOKEN` (GitHub App installation token from ESO, or PAT for local dev).
 
 ```bash
 export GITHUB_TOKEN="<github-app-installation-token-or-pat>"
 export RELIC_LIBRARIAN_USERNAME="librarian-bot"
+
+# 1. Create a feature branch
+aivcs pr branch --name feature/my-change --base main --owner stevedores-org --repo aivcs
+
+# 2. Commit a file to that branch
+aivcs pr commit \
+  --branch feature/my-change \
+  --path docs/example.md \
+  --file ./example.md \
+  --message "docs: add example" \
+  --owner stevedores-org \
+  --repo aivcs
+
+# 3. Open a PR (requests Librarian review by default)
 aivcs pr open \
   --owner stevedores-org \
   --repo aivcs \
@@ -163,6 +177,8 @@ aivcs pr open \
   --title "feat: my change" \
   --body  "Summary of what changed."
 ```
+
+`aivcs pr open` creates a Pull Request via the GitHub API and, by default, requests review from the Librarian Agent so it can audit changes before downstream OCI builds. This is the canonical PR-creation path used by autonomous builder agents running in ephemeral ADK Jobs.
 
 Required environment:
 

--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -569,20 +569,11 @@ async fn cmd_report_cross_org(
     let engine = AuditEngine::new(&graph);
     let audit = engine.audit();
 
-    // Aggregate health (using empty list if not implemented here)
-    let health = aivcs_core::CiHealthReport {
-        objective: _objective.to_string(),
-        repo_health: Vec::new(),
-        generated_at: chrono::Utc::now(),
-        all_healthy: true,
-        unhealthy_repos: Vec::new(),
-    };
-
     let artifact = CrossOrgAuditArtifact {
         generated_at: chrono::Utc::now(),
         coupling: audit.coupling,
         critical_spofs: audit.critical_spofs,
-        health,
+        health: None,
     };
 
     let report = render_cross_org_audit_md(&artifact);

--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -287,6 +287,52 @@ enum PrAction {
         #[arg(long, default_value_t = true)]
         librarian: bool,
     },
+
+    /// Create a GitHub branch from a base ref
+    Branch {
+        /// Branch name to create
+        #[arg(short, long)]
+        name: String,
+
+        /// Base branch or ref
+        #[arg(short, long, default_value = "main")]
+        base: String,
+
+        /// GitHub organization/owner
+        #[arg(long)]
+        owner: String,
+
+        /// GitHub repository name
+        #[arg(long)]
+        repo: String,
+    },
+
+    /// Commit a file to a GitHub branch via the Contents API
+    Commit {
+        /// Target branch
+        #[arg(short, long)]
+        branch: String,
+
+        /// Repository-relative file path
+        #[arg(short, long)]
+        path: String,
+
+        /// Commit message
+        #[arg(short, long)]
+        message: String,
+
+        /// Local file to upload
+        #[arg(short, long)]
+        file: PathBuf,
+
+        /// GitHub organization/owner
+        #[arg(long)]
+        owner: String,
+
+        /// GitHub repository name
+        #[arg(long)]
+        repo: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -537,6 +583,20 @@ async fn main() -> Result<()> {
                 repo,
                 librarian,
             } => cmd_pr_open(title, body, head, base, owner, repo, librarian).await,
+            PrAction::Branch {
+                name,
+                base,
+                owner,
+                repo,
+            } => cmd_pr_branch(name, base, owner, repo).await,
+            PrAction::Commit {
+                branch,
+                path,
+                message,
+                file,
+                owner,
+                repo,
+            } => cmd_pr_commit(branch, path, message, file, owner, repo).await,
         },
         Commands::Report { action } => match action {
             ReportAction::CrossOrg {
@@ -597,12 +657,7 @@ async fn cmd_pr_open(
     repo: String,
     librarian: bool,
 ) -> Result<()> {
-    use aivcs_core::github::GitHubClient;
-
-    let token =
-        std::env::var("GITHUB_TOKEN").context("GITHUB_TOKEN environment variable is required")?;
-
-    let client = GitHubClient::new(token, owner, repo)?;
+    let client = github_client_from_env(owner, repo)?;
 
     let pr_number = client
         .open_pr(&title, &body, &head, &base, librarian)
@@ -611,6 +666,39 @@ async fn cmd_pr_open(
     println!("Successfully opened PR #{}", pr_number);
 
     Ok(())
+}
+
+async fn cmd_pr_branch(name: String, base: String, owner: String, repo: String) -> Result<()> {
+    let client = github_client_from_env(owner, repo)?;
+    let sha = client.create_branch(&name, &base).await?;
+    println!("Created branch '{}' from '{}' ({})", name, base, sha);
+    Ok(())
+}
+
+async fn cmd_pr_commit(
+    branch: String,
+    path: String,
+    message: String,
+    file: PathBuf,
+    owner: String,
+    repo: String,
+) -> Result<()> {
+    let content = std::fs::read_to_string(&file)
+        .with_context(|| format!("Failed to read file for commit: {:?}", file))?;
+    let client = github_client_from_env(owner, repo)?;
+    client
+        .commit_file(&branch, &path, &content, &message)
+        .await?;
+    println!("Committed '{}' to branch '{}'", path, branch);
+    Ok(())
+}
+
+fn github_client_from_env(owner: String, repo: String) -> Result<aivcs_core::github::GitHubClient> {
+    use aivcs_core::github::GitHubClient;
+
+    let token =
+        std::env::var("GITHUB_TOKEN").context("GITHUB_TOKEN environment variable is required")?;
+    GitHubClient::new(token, owner, repo)
 }
 
 /// Initialize a new AIVCS repository
@@ -709,6 +797,14 @@ async fn cmd_snapshot(
     // Update branch head
     let branch_record = BranchRecord::new(branch, &commit_id.hash, branch == "main");
     handle.save_branch(&branch_record).await?;
+
+    aivcs_core::maybe_emit_code_committed_from_env(
+        branch,
+        &commit_id.hash,
+        vec![state_path.display().to_string()],
+        author,
+    )
+    .await;
 
     info!(
         cas_digest = %cas_digest,
@@ -935,6 +1031,14 @@ async fn cmd_merge(
     // Update target branch head
     let branch = BranchRecord::new(target, &result.merge_commit_id.hash, target == "main");
     handle.save_branch(&branch).await?;
+
+    aivcs_core::maybe_emit_code_committed_from_env(
+        target,
+        &result.merge_commit_id.hash,
+        Vec::new(),
+        "agent-git",
+    )
+    .await;
 
     println!("Merge complete: {}", result.merge_commit_id.short());
     println!("{}", result.summary);

--- a/crates/aivcs-core/src/a2a.rs
+++ b/crates/aivcs-core/src/a2a.rs
@@ -146,6 +146,46 @@ impl Default for A2aRetryPolicy {
     }
 }
 
+/// Emit `CODE_COMMITTED` when `AIVCS_A2A_JSONRPC_URL` is configured.
+///
+/// No-op when the endpoint env var is unset. Transport failures are logged and
+/// retried but never propagated to callers.
+pub async fn maybe_emit_code_committed_from_env(
+    branch: &str,
+    commit_sha: &str,
+    changed_paths: Vec<String>,
+    author: &str,
+) {
+    let Some(endpoint) = std::env::var("AIVCS_A2A_JSONRPC_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return;
+    };
+
+    let repo =
+        crate::git::detect_github_repository().unwrap_or_else(|| "unknown/unknown".to_string());
+    let method = std::env::var("AIVCS_A2A_JSONRPC_METHOD")
+        .unwrap_or_else(|_| DEFAULT_A2A_METHOD.to_string());
+    let authoring_agent_id = std::env::var("AIVCS_AGENT_ID").unwrap_or_else(|_| author.to_string());
+    let job_id = std::env::var("AIVCS_JOB_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+
+    let event = CodeCommittedEvent {
+        repo,
+        branch: branch.to_string(),
+        commit_sha: commit_sha.to_string(),
+        changed_paths,
+        authoring_agent_id,
+        job_id,
+        timestamp: Utc::now(),
+    };
+
+    let transport = HttpJsonRpcTransport::new(endpoint);
+    emit_code_committed_best_effort(&transport, &method, &event, A2aRetryPolicy::default()).await;
+}
+
 /// Emit a `CODE_COMMITTED` event. Transport failures are logged and swallowed.
 pub async fn emit_code_committed_best_effort<T: A2aTransport>(
     transport: &T,

--- a/crates/aivcs-core/src/git.rs
+++ b/crates/aivcs-core/src/git.rs
@@ -43,6 +43,48 @@ pub fn is_git_repo(dir: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Resolve `owner/name` for GitHub event payloads.
+///
+/// Prefers `GITHUB_REPOSITORY`, then parses `git remote get-url origin`.
+pub fn detect_github_repository() -> Option<String> {
+    std::env::var("GITHUB_REPOSITORY")
+        .ok()
+        .filter(|value| is_owner_repo(value))
+        .or_else(detect_github_repository_from_origin)
+}
+
+fn detect_github_repository_from_origin() -> Option<String> {
+    let output = Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let remote = String::from_utf8(output.stdout).ok()?;
+    parse_github_remote(remote.trim())
+}
+
+/// Parse `owner/name` from common GitHub remote URL formats.
+pub fn parse_github_remote(remote: &str) -> Option<String> {
+    let without_suffix = remote.strip_suffix(".git").unwrap_or(remote);
+    let candidate = without_suffix
+        .strip_prefix("git@github.com:")
+        .or_else(|| without_suffix.strip_prefix("https://github.com/"))?;
+
+    is_owner_repo(candidate).then(|| candidate.to_string())
+}
+
+fn is_owner_repo(value: &str) -> bool {
+    let mut parts = value.split('/');
+    matches!(
+        (parts.next(), parts.next(), parts.next()),
+        (Some(owner), Some(repo), None) if !owner.is_empty() && !repo.is_empty()
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,5 +139,23 @@ mod tests {
     fn is_git_repo_false_for_non_repo() {
         let dir = tempfile::tempdir().unwrap();
         assert!(!is_git_repo(dir.path()));
+    }
+
+    #[test]
+    fn parse_github_remote_supports_https_and_ssh() {
+        assert_eq!(
+            parse_github_remote("https://github.com/stevedores-org/aivcs.git"),
+            Some("stevedores-org/aivcs".to_string())
+        );
+        assert_eq!(
+            parse_github_remote("git@github.com:stevedores-org/aivcs.git"),
+            Some("stevedores-org/aivcs".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_github_remote_rejects_invalid_values() {
+        assert_eq!(parse_github_remote("https://gitlab.com/org/repo"), None);
+        assert_eq!(parse_github_remote("not-a-url"), None);
     }
 }

--- a/crates/aivcs-core/src/github.rs
+++ b/crates/aivcs-core/src/github.rs
@@ -161,8 +161,17 @@ impl GitHubClient {
 fn resolve_librarian_username(
     raw: std::result::Result<String, std::env::VarError>,
 ) -> Result<String> {
-    let value =
-        raw.context("RELIC_LIBRARIAN_USERNAME must be set to request a Librarian Agent review")?;
+    let value = match raw {
+        Ok(v) => v,
+        Err(std::env::VarError::NotPresent) => {
+            anyhow::bail!(
+                "RELIC_LIBRARIAN_USERNAME must be set to request a Librarian Agent review"
+            )
+        }
+        Err(std::env::VarError::NotUnicode(_)) => {
+            anyhow::bail!("RELIC_LIBRARIAN_USERNAME contains non-UTF-8 bytes")
+        }
+    };
     anyhow::ensure!(
         !value.trim().is_empty(),
         "RELIC_LIBRARIAN_USERNAME is set but empty"
@@ -209,14 +218,22 @@ mod tests {
     }
 
     #[test]
-    fn resolve_librarian_username_not_unicode_is_rejected() {
+    fn resolve_librarian_username_not_unicode_is_rejected_with_distinct_message() {
+        // NotUnicode means the env var IS set but contains invalid UTF-8 —
+        // distinguish it from "missing" so an operator debugging an ESO
+        // projection sees the real failure mode.
         let err = resolve_librarian_username(Err(VarError::NotUnicode(std::ffi::OsString::from(
             "ignored",
         ))))
         .unwrap_err();
+        let rendered = format!("{err:#}");
         assert!(
-            format!("{err:#}").contains("RELIC_LIBRARIAN_USERNAME must be set"),
-            "expected missing-env-style error for non-unicode value, got: {err:#}"
+            rendered.contains("non-UTF-8"),
+            "expected non-UTF-8-specific error, got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("must be set"),
+            "non-UTF-8 error must not claim the variable is unset, got: {rendered}"
         );
     }
 }

--- a/crates/aivcs-core/src/github.rs
+++ b/crates/aivcs-core/src/github.rs
@@ -128,9 +128,18 @@ impl GitHubClient {
     }
 
     /// Request a review from the Librarian Agent.
+    ///
+    /// The Librarian's GitHub username is read from `RELIC_LIBRARIAN_USERNAME`.
+    /// This is required when called: a missing or empty env var aborts before any
+    /// API call, rather than silently requesting review from a placeholder user
+    /// that may not exist and failing partway through a multi-step pipeline.
     pub async fn request_librarian_review(&self, pr_number: u64) -> Result<()> {
         let librarian = std::env::var("RELIC_LIBRARIAN_USERNAME")
-            .unwrap_or_else(|_| "librarian-agent".to_string());
+            .context("RELIC_LIBRARIAN_USERNAME must be set to request a Librarian Agent review")?;
+        anyhow::ensure!(
+            !librarian.trim().is_empty(),
+            "RELIC_LIBRARIAN_USERNAME is set but empty"
+        );
 
         info!(
             "Requesting review from Librarian Agent ('{}') on PR #{}",

--- a/crates/aivcs-core/src/github.rs
+++ b/crates/aivcs-core/src/github.rs
@@ -134,12 +134,7 @@ impl GitHubClient {
     /// API call, rather than silently requesting review from a placeholder user
     /// that may not exist and failing partway through a multi-step pipeline.
     pub async fn request_librarian_review(&self, pr_number: u64) -> Result<()> {
-        let librarian = std::env::var("RELIC_LIBRARIAN_USERNAME")
-            .context("RELIC_LIBRARIAN_USERNAME must be set to request a Librarian Agent review")?;
-        anyhow::ensure!(
-            !librarian.trim().is_empty(),
-            "RELIC_LIBRARIAN_USERNAME is set but empty"
-        );
+        let librarian = resolve_librarian_username(std::env::var("RELIC_LIBRARIAN_USERNAME"))?;
 
         info!(
             "Requesting review from Librarian Agent ('{}') on PR #{}",
@@ -154,5 +149,74 @@ impl GitHubClient {
             .context(format!("failed to request review for PR #{}", pr_number))?;
 
         Ok(())
+    }
+}
+
+/// Validate the raw `RELIC_LIBRARIAN_USERNAME` env-var lookup result.
+///
+/// Split out so the validation contract can be unit-tested without an HTTP
+/// client. A missing or whitespace-only value is rejected eagerly: the
+/// alternative is silently requesting review from a placeholder user that may
+/// not exist and failing partway through a multi-step pipeline.
+fn resolve_librarian_username(
+    raw: std::result::Result<String, std::env::VarError>,
+) -> Result<String> {
+    let value =
+        raw.context("RELIC_LIBRARIAN_USERNAME must be set to request a Librarian Agent review")?;
+    anyhow::ensure!(
+        !value.trim().is_empty(),
+        "RELIC_LIBRARIAN_USERNAME is set but empty"
+    );
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env::VarError;
+
+    #[test]
+    fn resolve_librarian_username_missing_env_is_rejected() {
+        let err = resolve_librarian_username(Err(VarError::NotPresent)).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("RELIC_LIBRARIAN_USERNAME must be set"),
+            "expected missing-env error, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn resolve_librarian_username_empty_string_is_rejected() {
+        let err = resolve_librarian_username(Ok(String::new())).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("set but empty"),
+            "expected empty-value error, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn resolve_librarian_username_whitespace_only_is_rejected() {
+        let err = resolve_librarian_username(Ok("   \t\n".to_string())).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("set but empty"),
+            "expected whitespace-only to be treated as empty, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn resolve_librarian_username_valid_value_is_returned_verbatim() {
+        let username = resolve_librarian_username(Ok("librarian-bot".to_string())).unwrap();
+        assert_eq!(username, "librarian-bot");
+    }
+
+    #[test]
+    fn resolve_librarian_username_not_unicode_is_rejected() {
+        let err = resolve_librarian_username(Err(VarError::NotUnicode(std::ffi::OsString::from(
+            "ignored",
+        ))))
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("RELIC_LIBRARIAN_USERNAME must be set"),
+            "expected missing-env-style error for non-unicode value, got: {err:#}"
+        );
     }
 }

--- a/crates/aivcs-core/src/lib.rs
+++ b/crates/aivcs-core/src/lib.rs
@@ -45,11 +45,11 @@ pub use domain::{
 pub use event_adapter::{subscribe_ledger_to_bus, LedgerHandler};
 
 pub use a2a::{
-    emit_code_committed_best_effort, A2aRetryPolicy, CodeCommittedEvent, HttpJsonRpcTransport,
-    DEFAULT_A2A_METHOD,
+    emit_code_committed_best_effort, maybe_emit_code_committed_from_env, A2aRetryPolicy,
+    CodeCommittedEvent, HttpJsonRpcTransport, DEFAULT_A2A_METHOD,
 };
 
-pub use git::{capture_head_sha, is_git_repo};
+pub use git::{capture_head_sha, detect_github_repository, is_git_repo, parse_github_remote};
 
 pub use memory::{DecisionRecorder, DecisionRecorderConfig};
 

--- a/crates/aivcs-core/src/reporting.rs
+++ b/crates/aivcs-core/src/reporting.rs
@@ -48,12 +48,16 @@ pub struct DiffSummaryArtifact {
 }
 
 /// Data model for cross-org integration audit report.
+///
+/// `health` is `Option` because the audit and the CI health report are computed
+/// independently — a caller may have one without the other. When `None`, the
+/// renderer surfaces "not available" rather than fabricating a healthy default.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CrossOrgAuditArtifact {
     pub generated_at: DateTime<Utc>,
     pub coupling: Vec<crate::multi_repo::audit::RepoCoupling>,
     pub critical_spofs: Vec<String>,
-    pub health: crate::multi_repo::aggregator::CiHealthReport,
+    pub health: Option<crate::multi_repo::aggregator::CiHealthReport>,
 }
 
 /// Write eval_results.json in pretty JSON format.
@@ -130,47 +134,51 @@ pub fn render_cross_org_audit_md(artifact: &CrossOrgAuditArtifact) -> String {
     }
 
     out.push_str("## Integration Health Summary\n\n");
-    let status_icon = if artifact.health.all_healthy {
-        "✅"
-    } else {
-        "❌"
-    };
-    out.push_str(&format!(
-        "Overall Status: {} {}\n\n",
-        status_icon,
-        if artifact.health.all_healthy {
-            "HEALTHY"
-        } else {
-            "DEGRADED"
-        }
-    ));
+    match &artifact.health {
+        Some(health) => {
+            let (status_icon, status_label) = if health.all_healthy {
+                ("✅", "HEALTHY")
+            } else {
+                ("❌", "DEGRADED")
+            };
+            out.push_str(&format!(
+                "Overall Status: {} {}\n\n",
+                status_icon, status_label
+            ));
 
-    out.push_str("| Repository | Status | Latest Run | Failing Stages |\n");
-    out.push_str("|---|---|---|---|\n");
-    for h in &artifact.health.repo_health {
-        let (status_text, icon) = match &h.status {
-            crate::multi_repo::aggregator::RepoHealthStatus::Healthy => ("Healthy", "✅"),
-            crate::multi_repo::aggregator::RepoHealthStatus::Degraded { .. } => ("Degraded", "⚠️"),
-            crate::multi_repo::aggregator::RepoHealthStatus::Down => ("Down", "❌"),
-            crate::multi_repo::aggregator::RepoHealthStatus::Unknown => ("Unknown", "❓"),
-        };
-        let failing = match &h.status {
-            crate::multi_repo::aggregator::RepoHealthStatus::Degraded { failing_stages } => {
-                failing_stages.join(", ")
+            out.push_str("| Repository | Status | Latest Run | Failing Stages |\n");
+            out.push_str("|---|---|---|---|\n");
+            for h in &health.repo_health {
+                let (status_text, icon) = match &h.status {
+                    crate::multi_repo::aggregator::RepoHealthStatus::Healthy => ("Healthy", "✅"),
+                    crate::multi_repo::aggregator::RepoHealthStatus::Degraded { .. } => {
+                        ("Degraded", "⚠️")
+                    }
+                    crate::multi_repo::aggregator::RepoHealthStatus::Down => ("Down", "❌"),
+                    crate::multi_repo::aggregator::RepoHealthStatus::Unknown => ("Unknown", "❓"),
+                };
+                let failing = match &h.status {
+                    crate::multi_repo::aggregator::RepoHealthStatus::Degraded {
+                        failing_stages,
+                    } => failing_stages.join(", "),
+                    _ => "-".to_string(),
+                };
+                let run_id = h
+                    .last_run
+                    .as_ref()
+                    .map(|r| r.run_id.chars().take(8).collect::<String>())
+                    .unwrap_or_else(|| "N/A".to_string());
+                out.push_str(&format!(
+                    "| `{}` | {} {} | `{}` | {} |\n",
+                    h.repo_id, icon, status_text, run_id, failing
+                ));
             }
-            _ => "-".to_string(),
-        };
-        let run_id = h
-            .last_run
-            .as_ref()
-            .map(|r| r.run_id.chars().take(8).collect::<String>())
-            .unwrap_or_else(|| "N/A".to_string());
-        out.push_str(&format!(
-            "| `{}` | {} {} | `{}` | {} |\n",
-            h.repo_id, icon, status_text, run_id, failing
-        ));
+            out.push('\n');
+        }
+        None => {
+            out.push_str("_Not available — no CI health data was provided to this report._\n\n");
+        }
     }
-    out.push('\n');
 
     out.push_str("## Recommendations\n\n");
     for c in &artifact.coupling {
@@ -178,13 +186,6 @@ pub fn render_cross_org_audit_md(artifact: &CrossOrgAuditArtifact) -> String {
             out.push_str(&format!("- **Decouple `{}`**: This repository has a very high blast radius ({}). Consider splitting it into smaller, more focused services or adding redundant fallback paths.\n", c.repo_id, c.blast_radius));
         }
     }
-
-    out.push_str("## Dependency Matrix (Mermaid)\n\n");
-    out.push_str("```mermaid\ngraph TD\n");
-    // We don't have the original graph here easily, but we can reconstruct it from coupling if we had more info
-    // or just pass it in. For now, a placeholder or simple list.
-    out.push_str("    %% [Dependency graph visualization]\n");
-    out.push_str("```\n");
 
     out
 }
@@ -257,5 +258,56 @@ mod tests {
         let actual = render_diff_summary_md(&artifact);
         let expected = "# Diff Summary\n\n## Spec\n- changed paths: 2\n- only in A: 1\n- only in B: 0\n\n### Changed Paths\n- `/model`\n- `/routing/strategy`\n\n## Run\n- events A: 12\n- events B: 14\n- added tool calls: 1\n- removed tool calls: 0\n- reordered tool calls: 2\n- param changed: 3\n";
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn cross_org_audit_md_without_health_says_not_available() {
+        use crate::multi_repo::audit::RepoCoupling;
+
+        let artifact = CrossOrgAuditArtifact {
+            generated_at: DateTime::parse_from_rfc3339("2026-05-29T00:00:00Z")
+                .expect("parse RFC3339")
+                .with_timezone(&Utc),
+            coupling: vec![
+                RepoCoupling {
+                    repo_id: "A".to_string(),
+                    direct_dependents: 2,
+                    blast_radius: 6,
+                    is_critical_path: true,
+                },
+                RepoCoupling {
+                    repo_id: "B".to_string(),
+                    direct_dependents: 0,
+                    blast_radius: 0,
+                    is_critical_path: false,
+                },
+            ],
+            critical_spofs: vec!["A".to_string()],
+            health: None,
+        };
+
+        let rendered = render_cross_org_audit_md(&artifact);
+
+        // Audit table is rendered.
+        assert!(rendered.contains("## Reliability Coupling Analysis"));
+        assert!(rendered.contains("| `A` | 2 | 6 | ⚠️ YES |"));
+        assert!(rendered.contains("| `B` | 0 | 0 | ok |"));
+
+        // SPOF section is rendered.
+        assert!(rendered.contains("Critical Single Points of Failure"));
+
+        // Health section says not available — must NOT claim HEALTHY/DEGRADED.
+        assert!(rendered.contains("## Integration Health Summary"));
+        assert!(rendered.contains("_Not available"));
+        assert!(!rendered.contains("HEALTHY"));
+        assert!(!rendered.contains("DEGRADED"));
+
+        // Recommendations exist because A.blast_radius > 5.
+        assert!(rendered.contains("## Recommendations"));
+        assert!(rendered.contains("Decouple `A`"));
+
+        // Mermaid placeholder section must be gone.
+        assert!(!rendered.contains("Dependency Matrix"));
+        assert!(!rendered.contains("Dependency graph visualization"));
     }
 }


### PR DESCRIPTION
## Summary

Completes the in-repo gaps for Epic #191 (Zero-touch PR pipeline):

- **Restores `CODE_COMMITTED` A2A emission** on `snapshot` and `merge` via `maybe_emit_code_committed_from_env` (regression fix — wiring from #193 was lost during later refactors)
- **Adds GitHub branch/commit CLI** (`aivcs pr branch`, `aivcs pr commit`) so autonomous agents can run the full branch → commit → PR flow through aivcs
- **Centralizes repo detection** in `git::detect_github_repository` for A2A payloads
- **Documents** the three-step autonomous GitHub workflow in README

Part of #191

## Test plan

- [x] `cargo test -p aivcs-core -- git::tests a2a::tests`
- [x] `cargo check -p aivcs-cli`
- [x] Pre-commit local-ci (fmt + clippy) passed
- [ ] Manual: `AIVCS_A2A_JSONRPC_URL=... aivcs snapshot ...` emits event
- [ ] Manual: `GITHUB_TOKEN=... aivcs pr branch/commit/open` against a test repo

## Notes

Epic-level token minting via ESO (task 2.2 / crossplane-heaven#6) remains out of scope; this PR assumes `GITHUB_TOKEN` is already projected into the Job pod.


Made with [Cursor](https://cursor.com)