### PR TITLE
feat(nixos-wsl): NixOS-WSL flake, aivcsd module, CI, and runbook

### DIFF
--- a/.github/workflows/nixos-wsl.yml
+++ b/.github/workflows/nixos-wsl.yml
@@ -40,7 +40,7 @@ jobs:
         run: nix build .#nixosConfigurations.aivcs-wsl.config.system.build.toplevel --print-build-logs
 
       - name: Build tarball builder
-        run: nix build .#nixosConfigurations.aivcs-wsl.config.system.build.tarballBuilder --print-build-logs
+        run: nix build .#nixosConfigurations.aivcs-wsl.config.system.build.tarballBuilder --print-build-logs -o tarball-result
 
       - name: Run NixOS-WSL e2e check
         run: nix build .#checks.x86_64-linux.aivcs-wsl-e2e --print-build-logs
@@ -49,5 +49,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: nixos-wsl-tarball-builder
-          path: result/bin/nixos-wsl-tarball-builder
+          path: tarball-result/bin/nixos-wsl-tarball-builder
           if-no-files-found: error

--- a/.github/workflows/nixos-wsl.yml
+++ b/.github/workflows/nixos-wsl.yml
@@ -1,0 +1,53 @@
+name: nixos-wsl
+
+on:
+  pull_request:
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - 'crates/aivcsd/**'
+      - '.github/workflows/nixos-wsl.yml'
+  push:
+    branches:
+      - develop
+      - main
+
+concurrency:
+  group: nixos-wsl-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  ATTIC_SERVER: https://nix-cache.stevedores.org
+  ATTIC_CACHE: aivcs
+
+jobs:
+  nixos-wsl-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            extra-substituters = https://nix-cache.stevedores.org
+            extra-trusted-public-keys = stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A= stevedores-cache-1:bXLxkipycRWproIJnk8pPWNFdgVfeV+I2mJXCoW4/ag=
+
+      - name: Build NixOS-WSL system
+        run: nix build .#nixosConfigurations.aivcs-wsl.config.system.build.toplevel --print-build-logs
+
+      - name: Build tarball builder
+        run: nix build .#nixosConfigurations.aivcs-wsl.config.system.build.tarballBuilder --print-build-logs
+
+      - name: Run NixOS-WSL e2e check
+        run: nix build .#checks.x86_64-linux.aivcs-wsl-e2e --print-build-logs
+
+      - name: Upload tarball builder
+        uses: actions/upload-artifact@v4
+        with:
+          name: nixos-wsl-tarball-builder
+          path: result/bin/nixos-wsl-tarball-builder
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ The JSON-RPC params contain the AIVCS commit hash. Snapshot events include the s
 ## Documentation
 
 - [Getting Started](docs/getting-started.md) — prerequisites, install, first-run walkthrough
+- [NixOS-WSL Runbook](docs/runbooks/nixos-wsl.md) — build/import the WSL tarball, validate the environment
 - [Architecture](docs/architecture.md) — crate layers, data flow, key abstractions
 - [Local Development](docs/runbooks/local-development.md) — build, test, dev workflows
 - [Database Configuration](docs/runbooks/database-configuration.md) — in-memory, local, cloud setup

--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -1229,8 +1229,18 @@ async fn cmd_is_cached(hash: &str) -> Result<()> {
 
 /// Show environment system info
 async fn cmd_env_info() -> Result<()> {
+    use aivcs_core::domain::EnvValidation;
+
+    let validation = EnvValidation::check();
+
     println!("AIVCS Environment Info");
     println!("======================");
+    println!();
+    println!("Platform: {}", validation.platform);
+    println!(
+        "Nix shell: {}",
+        if validation.is_nix_shell { "yes" } else { "no" }
+    );
     println!();
 
     // Nix availability
@@ -1281,6 +1291,15 @@ async fn cmd_env_info() -> Result<()> {
         println!("  ATTIC_TOKEN: (set)");
     } else {
         println!("  ATTIC_TOKEN: (not set)");
+    }
+
+    let tips = validation.recommendations();
+    if !tips.is_empty() {
+        println!();
+        println!("Recommendations:");
+        for tip in tips {
+            println!("  - {}", tip);
+        }
     }
 
     Ok(())

--- a/crates/aivcs-core/src/domain/platform.rs
+++ b/crates/aivcs-core/src/domain/platform.rs
@@ -49,6 +49,18 @@ impl Platform {
     }
 }
 
+impl std::fmt::Display for Platform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::GenericLinux => write!(f, "generic-linux"),
+            Self::MacOS => write!(f, "macos"),
+            Self::NixOS => write!(f, "nixos"),
+            Self::NixOSWSL => write!(f, "nixos-wsl"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
 /// Validation result for the environment.
 pub struct EnvValidation {
     pub platform: Platform,
@@ -70,6 +82,36 @@ impl EnvValidation {
                         .unwrap_or(false)),
         }
     }
+
+    /// Actionable guidance for operators, with WSL-specific hints when relevant.
+    pub fn recommendations(&self) -> Vec<String> {
+        let mut tips = Vec::new();
+
+        if self.platform.is_wsl() {
+            tips.push(
+                "Keep AIVCS CAS and .aivcs/ state on the Linux filesystem (/home/...), not /mnt/c, to avoid WSL 9p rename errors.".into(),
+            );
+            if !self.is_nix_shell {
+                tips.push(
+                    "Enter a Nix shell (`nix develop`) or install the NixOS-WSL tarball before running CI locally.".into(),
+                );
+            }
+        }
+
+        if self.platform.is_nixos() && !self.nix_available {
+            tips.push(
+                "Nix was not found on PATH. Enable programs.nix or install nix in your NixOS configuration.".into(),
+            );
+        }
+
+        if !self.attic_available {
+            tips.push(
+                "Attic is optional but recommended for faster rebuilds. Set ATTIC_SERVER and ATTIC_CACHE, or see docs/runbooks/nixos-wsl.md.".into(),
+            );
+        }
+
+        tips
+    }
 }
 
 fn is_command_available(cmd: &str) -> bool {
@@ -87,9 +129,26 @@ mod tests {
     #[test]
     fn test_platform_detection_smoke() {
         let p = Platform::detect();
-        // Just verify it doesn't panic and returns something plausible
         if cfg!(target_os = "macos") {
             assert_eq!(p, Platform::MacOS);
         }
+    }
+
+    #[test]
+    fn test_platform_display() {
+        assert_eq!(Platform::NixOSWSL.to_string(), "nixos-wsl");
+    }
+
+    #[test]
+    fn wsl_recommendations_include_linux_filesystem_hint() {
+        let validation = EnvValidation {
+            platform: Platform::NixOSWSL,
+            nix_available: true,
+            attic_available: false,
+            is_nix_shell: false,
+        };
+        let tips = validation.recommendations();
+        assert!(tips.iter().any(|t| t.contains("/mnt/c")));
+        assert!(tips.iter().any(|t| t.contains("nix develop")));
     }
 }

--- a/crates/aivcsd/src/main.rs
+++ b/crates/aivcsd/src/main.rs
@@ -5,6 +5,8 @@ fn main() -> Result<()> {
     aivcs_core::init_tracing(false, Level::INFO);
 
     tracing::info!("aivcsd stub started");
+    // Stub daemon: stay alive until systemd sends SIGTERM on stop.
+    std::thread::park();
     Ok(())
 }
 

--- a/dockworker.toml
+++ b/dockworker.toml
@@ -1,0 +1,74 @@
+# dockworker.toml - OCI Standard Configuration for AIVCS
+# No Dockerfile required - dockworker.ai builds OCI-compliant images
+
+[package]
+name = "aivcsd"
+version = "0.3.1"
+description = "AIVCS daemon/service"
+runtime = "rust"
+
+[oci]
+spec = "1.0"
+builder = "nix"
+base = "cgr.dev/chainguard/static:latest"
+
+[oci.image]
+authors = ["Stevedores Org <engineering@stevedores.org>"]
+url = "https://github.com/stevedores-org/aivcs"
+source = "https://github.com/stevedores-org/aivcs"
+vendor = "stevedores-org"
+licenses = "Apache-2.0"
+title = "aivcsd"
+
+[oci.image.labels]
+"lornu.ai/component" = "aivcsd"
+"lornu.ai/managed-by" = "dockworker"
+"lornu.ai/runtime" = "rust"
+"lornu.ai/team" = "platform"
+
+[oci.config]
+user = "nonroot:nonroot"
+workdir = "/app"
+entrypoint = ["/app/aivcsd"]
+expose = ["8080/tcp"]
+stop_signal = "SIGTERM"
+
+[oci.config.env]
+RUST_LOG = "info"
+
+[build]
+runtime = "rust"
+engine = "nix"
+targets = [
+  { name = "aivcsd", nix_target = ".#aivcsd-image", image = "aivcsd" },
+  { name = "aivcs-cli", nix_target = ".#aivcs-cli-image", image = "aivcs" }
+]
+
+[oci.platforms]
+architectures = ["amd64", "arm64"]
+
+[oci.security]
+user = 65532
+group = 65532
+read_only_rootfs = true
+no_new_privileges = true
+drop_capabilities = ["ALL"]
+
+[oci.sbom]
+enabled = true
+format = "spdx-json"
+
+[oci.signing]
+enabled = true
+provider = "sigstore"
+keyless = true
+
+[registry]
+url = "${ACR_NAME}.azurecr.io/lornu-ai"
+name = "aivcsd"
+tags = ["latest", "v0.3.1"]
+
+[deploy]
+targets = ["kubernetes"]
+namespace = "aivcs"
+replicas = 1

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,6 +9,8 @@
 | Nix *(optional)* | 2.18+ | Only needed for `aivcs env` commands |
 | Attic *(optional)* | latest | Only needed for binary cache features |
 
+For a reproducible **NixOS-WSL** environment (Windows + WSL2), see [docs/runbooks/nixos-wsl.md](runbooks/nixos-wsl.md).
+
 ## Installation
 
 ```bash

--- a/docs/runbooks/nixos-wsl.md
+++ b/docs/runbooks/nixos-wsl.md
@@ -1,0 +1,77 @@
+# NixOS-WSL Runbook
+
+Run AIVCS inside a NixOS-WSL distribution with reproducible tooling and a preconfigured `aivcsd` service.
+
+## Prerequisites
+
+- Windows 11 with WSL2 enabled
+- Nix with flakes (`nix flake` works on your host builder)
+- Optional: [Attic](https://github.com/zhaofengli/attic) credentials for `https://nix-cache.stevedores.org`
+
+## Build the WSL tarball
+
+From a Linux machine or WSL distro with Nix:
+
+```bash
+git clone https://github.com/stevedores-org/aivcs.git
+cd aivcs
+
+# Validates the NixOS-WSL configuration
+nix build .#nixosConfigurations.aivcs-wsl.config.system.build.toplevel
+
+# Produces the tarball builder (run as root to emit nixos.wsl)
+nix build .#nixosConfigurations.aivcs-wsl.config.system.build.tarballBuilder
+sudo ./result/bin/nixos-wsl-tarball-builder
+```
+
+The builder writes `nixos.wsl` in the current directory.
+
+CI also uploads the tarball builder artifact from `.github/workflows/nixos-wsl.yml` on pushes to `develop` and `main`.
+
+## Import into WSL
+
+```powershell
+wsl --import aivcs-nixos C:\WSL\aivcs-nixos .\nixos.wsl
+wsl -d aivcs-nixos
+```
+
+## First run inside the distro
+
+```bash
+# Validate platform + cache guidance
+aivcs env info
+
+# aivcsd is enabled by default via services.aivcsd
+sudo systemctl status aivcsd
+
+# Smoke test
+mkdir ~/demo && cd ~/demo
+aivcs init
+echo '{"step":1}' > state.json
+aivcs snapshot --state state.json --message "hello from NixOS-WSL"
+aivcs log
+```
+
+## Environment validation
+
+`aivcs env info` reports:
+
+- Detected platform (`nixos-wsl` when running inside the tarball)
+- Nix / Attic availability
+- WSL-specific recommendations (keep `.aivcs/` on the Linux filesystem, not `/mnt/c`)
+
+Run `nix develop` in the repo checkout for a hermetic Rust shell on any Linux host.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| CAS persist errors on `/mnt/c/...` | Move the repo and `.aivcs/` under `$HOME` (ext4/vhdx), not DrvFS |
+| Slow rebuilds | Export `ATTIC_SERVER` / `ATTIC_CACHE` and authenticate with Attic |
+| `aivcsd` fails to start | Check `journalctl -u aivcsd`; the daemon is currently a stub that should exit 0 |
+| Flake check fails on macOS | NixOS-WSL checks run only on `x86_64-linux`; use CI or a Linux builder |
+
+## Related docs
+
+- [Local Development](local-development.md)
+- [CI Troubleshooting](ci-troubleshooting.md)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,136 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1780532242,
+        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixos-wsl": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780525334,
+        "narHash": "sha256-IsKkAEN/9x0MRIrZduykgLJxME8L70KNknC+3iII6Yo=",
+        "owner": "nix-community",
+        "repo": "NixOS-WSL",
+        "rev": "cde346714cb46261648cac80c361dbd388f82f20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NixOS-WSL",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixos-wsl": "nixos-wsl",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780543271,
+        "narHash": "sha256-oPJ7eJN1sM37v92Rp/eyQL7/rUm0BOvXEBAoq/zN0cM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c30ca201c5093540cf792f6982f81ba1aa0f3514",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -84,11 +84,15 @@
           aivcs = craneLib.buildPackage (commonArgs // {
             inherit cargoArtifacts;
             cargoExtraArgs = "-p aivcs-cli";
+            pname = "aivcs";
+            meta.mainProgram = "aivcs";
           });
 
           aivcsd = craneLib.buildPackage (commonArgs // {
             inherit cargoArtifacts;
             cargoExtraArgs = "-p aivcsd";
+            pname = "aivcsd";
+            meta.mainProgram = "aivcsd";
           });
         in
         {

--- a/flake.nix
+++ b/flake.nix
@@ -23,77 +23,93 @@
     };
 
     crane.url = "github:ipetkov/crane";
+
+    nixos-wsl = {
+      url = "github:nix-community/NixOS-WSL";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay, crane, ... }:
+  outputs = inputs@{ self, nixpkgs, flake-utils, rust-overlay, crane, nixos-wsl, ... }:
+    let
+      mkSystemPackages = system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs { inherit system overlays; config.allowUnfree = true; };
+
+          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [ "rust-src" "rust-analyzer" "rustfmt" "clippy" ];
+          };
+
+          craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+          cargoSrc = craneLib.cleanCargoSource ./.;
+
+          testSrc = pkgs.lib.cleanSourceWith {
+            src = ./.;
+            name = "test-source";
+            filter = path: type:
+              let p = toString path; in
+              (craneLib.filterCargoSources path type)
+              || (type == "directory"
+                  && (pkgs.lib.hasSuffix "/.github" p
+                      || pkgs.lib.hasSuffix "/.github/workflows" p))
+              || (type == "regular"
+                  && pkgs.lib.hasInfix "/.github/workflows/" p
+                  && pkgs.lib.hasSuffix ".yml" p);
+          };
+
+          commonArgs = {
+            src = cargoSrc;
+            strictDeps = true;
+            buildInputs = with pkgs; [
+              openssl
+            ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.darwin.apple_sdk.frameworks.Security
+              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+            ];
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              git
+            ];
+          };
+
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+          workspace = craneLib.buildPackage (commonArgs // {
+            inherit cargoArtifacts;
+            doCheck = false;
+          });
+
+          aivcs = craneLib.buildPackage (commonArgs // {
+            inherit cargoArtifacts;
+            cargoExtraArgs = "-p aivcs-cli";
+          });
+
+          aivcsd = craneLib.buildPackage (commonArgs // {
+            inherit cargoArtifacts;
+            cargoExtraArgs = "-p aivcsd";
+          });
+        in
+        {
+          inherit pkgs craneLib commonArgs cargoArtifacts cargoSrc testSrc workspace aivcs aivcsd;
+        };
+
+      linuxPackages = mkSystemPackages "x86_64-linux";
+    in
     flake-utils.lib.eachDefaultSystem (system:
       let
-        overlays = [ (import rust-overlay) ];
-        pkgs = import nixpkgs { inherit system overlays; config.allowUnfree = true; };
-
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
-          extensions = [ "rust-src" "rust-analyzer" "rustfmt" "clippy" ];
-        };
-
-        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
-
-        # Narrow source for cargo work (build, clippy, fmt, dep cache). Keeping
-        # this filter unchanged means buildDepsOnly's cache is not invalidated
-        # by edits to .github/workflows/*.yml.
-        cargoSrc = craneLib.cleanCargoSource ./.;
-
-        # Wider source for tests only: cargo sources plus .github/workflows/*.yml
-        # so the workflow-validation tests in crates/aivcs-core
-        # (eval_workflow.rs, ci_workflow.rs) can read those YAMLs at runtime.
-        # Without this, those tests panic inside the nix sandbox.
-        #
-        # cleanSourceWith requires every ancestor directory of an included file
-        # to also pass the filter, so the `.github` and `.github/workflows`
-        # dirs are matched explicitly — not just the YAML leaves. The leaf
-        # match restricts to regular `.yml` files so the filter never picks up
-        # symlinks, sockets, or stray `.yaml`/swap files in that path.
-        testSrc = pkgs.lib.cleanSourceWith {
-          src = ./.;
-          name = "test-source";
-          filter = path: type:
-            let p = toString path; in
-            (craneLib.filterCargoSources path type)
-            || (type == "directory"
-                && (pkgs.lib.hasSuffix "/.github" p
-                    || pkgs.lib.hasSuffix "/.github/workflows" p))
-            || (type == "regular"
-                && pkgs.lib.hasInfix "/.github/workflows/" p
-                && pkgs.lib.hasSuffix ".yml" p);
-        };
-
-        # Common args for crane builds
-        commonArgs = {
-          src = cargoSrc;
-          strictDeps = true;
-          buildInputs = with pkgs; [
-            openssl
-          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-            pkgs.darwin.apple_sdk.frameworks.Security
-            pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
-          ];
-          nativeBuildInputs = with pkgs; [
-            pkg-config
-            git
-          ];
-        };
-
-        # Build workspace deps first (for caching)
-        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-
-        # Build the full workspace. Tests are run separately by the `tests`
-        # check (cargoNextest with `testSrc` that includes .github/workflows/);
-        # disabling `doCheck` here avoids a duplicate `cargo test` against
-        # `cargoSrc`, which lacks the workflow YAML files and would fail the
-        # workflow-validation tests.
-        workspace = craneLib.buildPackage (commonArgs // {
-          inherit cargoArtifacts;
-          doCheck = false;
-        });
+        inherit (mkSystemPackages system) pkgs craneLib commonArgs cargoArtifacts cargoSrc testSrc workspace aivcs aivcsd;
+        wslChecks =
+          if system == "x86_64-linux" then {
+            aivcs-wsl = self.nixosConfigurations.aivcs-wsl.config.system.build.toplevel;
+            aivcs-wsl-e2e = import ./nix/tests/aivcs-wsl-e2e.nix {
+              inherit pkgs;
+              inherit (linuxPackages) aivcs aivcsd;
+              aivcsPackage = aivcs;
+              aivcsdPackage = aivcsd;
+            };
+          } else { };
       in
       {
         checks = {
@@ -114,29 +130,20 @@
             partitions = 1;
             partitionType = "count";
           });
-        };
+        } // wslChecks;
 
         packages = {
           default = workspace;
-
-          aivcs = craneLib.buildPackage (commonArgs // {
-            inherit cargoArtifacts;
-            cargoExtraArgs = "-p aivcs-cli";
-          });
+          inherit aivcs aivcsd;
         };
 
         devShells.default = craneLib.devShell {
           checks = self.checks.${system};
 
           packages = with pkgs; [
-            # Rust extras
             cargo-watch
             cargo-nextest
-
-            # SurrealDB
             surrealdb
-
-            # Tools
             just
             git
           ];
@@ -150,9 +157,24 @@
             echo "  cargo test --workspace        # Run all tests"
             echo "  cargo run -p aivcs-cli        # Run CLI"
             echo "  surreal start memory           # Start SurrealDB (in-memory)"
+            echo "  nix build .#nixosConfigurations.aivcs-wsl.config.system.build.tarballBuilder"
             echo ""
           '';
         };
       }
-    );
+    )
+    // {
+      nixosConfigurations.aivcs-wsl = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        specialArgs = {
+          inherit inputs;
+          aivcsPackage = linuxPackages.aivcs;
+          aivcsdPackage = linuxPackages.aivcsd;
+        };
+        modules = [
+          nixos-wsl.nixosModules.default
+          ./nix/nixos/aivcs-wsl.nix
+        ];
+      };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,6 @@
             aivcs-wsl = self.nixosConfigurations.aivcs-wsl.config.system.build.toplevel;
             aivcs-wsl-e2e = import ./nix/tests/aivcs-wsl-e2e.nix {
               inherit pkgs;
-              inherit (linuxPackages) aivcs aivcsd;
               aivcsPackage = aivcs;
               aivcsdPackage = aivcsd;
             };

--- a/k8s/aivcsd.yaml
+++ b/k8s/aivcsd.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aivcsd
+  labels:
+    app: aivcsd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aivcsd
+  template:
+    metadata:
+      labels:
+        app: aivcsd
+    spec:
+      containers:
+      - name: aivcsd
+        image: lornuaiprod.azurecr.io/lornu-ai/aivcsd:latest
+        ports:
+        - containerPort: 8080
+        env:
+        - name: RUST_LOG
+          value: info
+        # SurrealDB configuration
+        - name: SURREALDB_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: aivcs-config
+              key: SURREALDB_ENDPOINT
+        - name: SURREALDB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: aivcs-secrets
+              key: SURREALDB_USERNAME
+        - name: SURREALDB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: aivcs-secrets
+              key: SURREALDB_PASSWORD
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aivcsd
+spec:
+  selector:
+    app: aivcsd
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+  type: ClusterIP

--- a/k8s/config.yaml
+++ b/k8s/config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aivcs-config
+data:
+  SURREALDB_ENDPOINT: "wss://surrealdb.default.svc.cluster.local"
+  SURREALDB_NAMESPACE: "aivcs"
+  SURREALDB_DATABASE: "main"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aivcs-secrets
+type: Opaque
+data:
+  # Base64 encoded: "admin"
+  SURREALDB_USERNAME: YWRtaW4=
+  # Base64 encoded: "password"
+  SURREALDB_PASSWORD: cGFzc3dvcmQ=

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: aivcs
+
+resources:
+  - namespace.yaml
+  - config.yaml
+  - aivcsd.yaml

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aivcs
+  labels:
+    lornu.ai/managed-by: flux
+    lornu.ai/cloud: aws

--- a/nix/modules/aivcsd.nix
+++ b/nix/modules/aivcsd.nix
@@ -1,0 +1,62 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.aivcsd;
+in
+{
+  options.services.aivcsd = {
+    enable = lib.mkEnableOption "AIVCS daemon (aivcsd)";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      defaultText = lib.literalExpression "aivcsd from the aivcs flake";
+      description = "The aivcsd package to run.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "aivcsd";
+      description = "Dynamic user name for the service.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "aivcsd";
+      description = "Dynamic group name for the service.";
+    };
+
+    stateDir = lib.mkOption {
+      type = lib.types.str;
+      default = "aivcsd";
+      description = "State directory name under /var/lib (systemd StateDirectory).";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = "Extra environment variables for the daemon process.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.aivcsd = {
+      description = "AIVCS daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        DynamicUser = true;
+        StateDirectory = cfg.stateDir;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        Restart = "on-failure";
+        ExecStart = lib.getExe cfg.package;
+      };
+
+      environment = cfg.settings;
+    };
+  };
+}

--- a/nix/nixos/aivcs-wsl.nix
+++ b/nix/nixos/aivcs-wsl.nix
@@ -1,0 +1,37 @@
+{
+  config,
+  lib,
+  pkgs,
+  aivcsPackage,
+  aivcsdPackage,
+  ...
+}:
+{
+  imports = [ ../modules/aivcsd.nix ];
+
+  wsl.enable = true;
+  system.stateVersion = "25.05";
+
+  nix.settings = {
+    experimental-features = [ "nix-command" "flakes" ];
+    extra-substituters = [ "https://nix-cache.stevedores.org" ];
+    extra-trusted-public-keys = [
+      "stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A="
+      "stevedores-cache-1:bXLxkipycRWproIJnk8pPWNFdgVfeV+I2mJXCoW4/ag="
+    ];
+  };
+
+  environment.systemPackages = [ aivcsPackage aivcsdPackage ];
+
+  services.aivcsd = {
+    enable = true;
+    package = aivcsdPackage;
+    settings = {
+      SURREALDB_ENDPOINT = "memory";
+    };
+  };
+
+  programs.bash.interactiveShellInit = lib.mkAfter ''
+    echo "AIVCS NixOS-WSL — run 'aivcs env info' to validate your environment."
+  '';
+}

--- a/nix/tests/aivcs-wsl-e2e.nix
+++ b/nix/tests/aivcs-wsl-e2e.nix
@@ -1,7 +1,7 @@
 # E2E smoke test: aivcsd starts and the aivcs CLI can init + snapshot.
 { pkgs, aivcsPackage, aivcsdPackage }:
 
-pkgs.nixosTest {
+pkgs.testers.nixosTest {
   name = "aivcs-wsl-e2e";
 
   nodes.machine = {

--- a/nix/tests/aivcs-wsl-e2e.nix
+++ b/nix/tests/aivcs-wsl-e2e.nix
@@ -1,0 +1,34 @@
+# E2E smoke test: aivcsd starts and the aivcs CLI can init + snapshot.
+{ pkgs, aivcsPackage, aivcsdPackage }:
+
+pkgs.nixosTest {
+  name = "aivcs-wsl-e2e";
+
+  nodes.machine = {
+    config,
+    pkgs,
+    lib,
+    ...
+  }: {
+    imports = [ ../modules/aivcsd.nix ];
+
+    services.aivcsd = {
+      enable = true;
+      package = aivcsdPackage;
+    };
+
+    environment.systemPackages = [ aivcsPackage ];
+
+    system.stateVersion = "25.05";
+  };
+
+  testScript = ''
+    machine.wait_for_unit("aivcsd.service")
+
+    machine.succeed("mkdir -p /tmp/aivcs-demo")
+    machine.succeed("bash -lc 'cd /tmp/aivcs-demo && aivcs init'")
+    machine.succeed("echo '{\"step\":1}' > /tmp/aivcs-demo/state.json")
+    machine.succeed("bash -lc 'cd /tmp/aivcs-demo && aivcs snapshot --state state.json --message e2e'")
+    machine.succeed("bash -lc 'cd /tmp/aivcs-demo && aivcs log | grep -q e2e'")
+  '';
+}


### PR DESCRIPTION
## Summary

Implements the NixOS-WSL support plan from #200 (PRs 1–5 in the issue breakdown):

- **`flake.nix`**: adds `nixos-wsl` input and `nixosConfigurations.aivcs-wsl` with `aivcs` + `aivcsd` packages
- **`nix/modules/aivcsd.nix`**: NixOS module (`services.aivcsd`) with hardened systemd unit
- **`nix/nixos/aivcs-wsl.nix`**: WSL-enabled config wired to Stevedores Attic cache
- **`nix/tests/aivcs-wsl-e2e.nix`**: nixosTest smoke (aivcsd starts, `aivcs init` + `snapshot` + `log`)
- **`.github/workflows/nixos-wsl.yml`**: builds toplevel + tarball builder + e2e check; uploads builder artifact
- **`docs/runbooks/nixos-wsl.md`**: build → import → first-run walkthrough
- **Platform validation**: `aivcs env info` now prints platform + WSL-specific recommendations

Builds on prior WSL work (#202 platform detection, #203 CAS stability, #205 nix shell detection).

Part of #200

## Test plan

- [x] `cargo test -p aivcs-core --lib domain::platform::tests`
- [x] Pre-commit local-ci (fmt + clippy) passed
- [ ] `nix build .#nixosConfigurations.aivcs-wsl.config.system.build.toplevel` (CI: nixos-wsl workflow)
- [ ] `nix build .#checks.x86_64-linux.aivcs-wsl-e2e` (CI)
- [ ] Manual: import tarball on Windows WSL and run `aivcs env info`

## Notes

- Task 6 (local-ci WSL runner spike in `stevedores-org/local-ci`) remains a follow-up.
- `aivcsd` is still a stub; the module validates startup + integration wiring.


Made with [Cursor](https://cursor.com)