### PR TITLE
feat(pr-commit): return SHA, reject binary clearly, ssh:// remote, A2A env docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,23 @@ Required environment:
 
 The `--librarian` flag defaults to `true`; pass `--librarian=false` to skip the review request in development or test contexts where the Librarian is not deployed.
 
+#### A2A `CODE_COMMITTED` emission
+
+`aivcs snapshot` and `aivcs merge` emit a `CODE_COMMITTED` Agent-to-Agent event when the JSON-RPC URL is configured. The repo is resolved from `GITHUB_REPOSITORY` if set, otherwise from `git remote get-url origin`. The emission is no-op when the URL var is absent.
+
+| Variable | Description |
+|----------|-------------|
+| `AIVCS_A2A_JSONRPC_URL` | JSON-RPC endpoint to POST the event to. Absent or whitespace-only ⇒ no emission. |
+| `AIVCS_A2A_JSONRPC_METHOD` | Override the JSON-RPC method name. Defaults to `event.code_committed`. |
+| `AIVCS_AGENT_ID` | Authoring agent identifier in the event payload. Falls back to the local commit author. |
+| `AIVCS_JOB_ID` | Optional job/run correlation ID. Whitespace-only values are dropped. |
+
+> ⚠️ The emission is awaited synchronously inside `snapshot` / `merge`. Transport failures retry per `A2aRetryPolicy::default()` before returning; the CLI blocks for that window. Pin the retry policy if you tighten snapshot-latency SLOs.
+
+#### `pr commit` and file content
+
+`aivcs pr commit` reads `--file` as UTF-8 text. Binary files are rejected with an actionable error before the API call. Binary commits via the Contents API require a different code path; see the inner `commit_file` doc.
+
 ## Documentation
 
 - [Getting Started](docs/getting-started.md) — prerequisites, install, first-run walkthrough

--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -683,13 +683,24 @@ async fn cmd_pr_commit(
     owner: String,
     repo: String,
 ) -> Result<()> {
-    let content = std::fs::read_to_string(&file)
+    // Read as bytes + UTF-8 validate explicitly so the operator sees an
+    // actionable message for binary files instead of the opaque default
+    // ("stream did not contain valid UTF-8"). Binary commits would need
+    // a different code path through the Contents API — tracked separately.
+    let bytes = tokio::fs::read(&file)
+        .await
         .with_context(|| format!("Failed to read file for commit: {:?}", file))?;
+    let content = std::str::from_utf8(&bytes).map_err(|err| {
+        anyhow::anyhow!(
+            "File {file:?} is not valid UTF-8 ({err}). Binary file commits via `aivcs pr commit` are not yet supported."
+        )
+    })?;
+
     let client = github_client_from_env(owner, repo)?;
-    client
-        .commit_file(&branch, &path, &content, &message)
+    let sha = client
+        .commit_file(&branch, &path, content, &message)
         .await?;
-    println!("Committed '{}' to branch '{}'", path, branch);
+    println!("Committed '{path}' to branch '{branch}' ({sha})");
     Ok(())
 }
 

--- a/crates/aivcs-core/src/git.rs
+++ b/crates/aivcs-core/src/git.rs
@@ -68,11 +68,17 @@ fn detect_github_repository_from_origin() -> Option<String> {
 }
 
 /// Parse `owner/name` from common GitHub remote URL formats.
+///
+/// Supported shapes (trailing `.git` is stripped before matching):
+/// - `git@github.com:owner/name` (SCP-style SSH — the default git output)
+/// - `https://github.com/owner/name`
+/// - `ssh://git@github.com/owner/name` (RFC-style SSH that some tooling emits)
 pub fn parse_github_remote(remote: &str) -> Option<String> {
     let without_suffix = remote.strip_suffix(".git").unwrap_or(remote);
     let candidate = without_suffix
         .strip_prefix("git@github.com:")
-        .or_else(|| without_suffix.strip_prefix("https://github.com/"))?;
+        .or_else(|| without_suffix.strip_prefix("https://github.com/"))
+        .or_else(|| without_suffix.strip_prefix("ssh://git@github.com/"))?;
 
     is_owner_repo(candidate).then(|| candidate.to_string())
 }
@@ -149,6 +155,21 @@ mod tests {
         );
         assert_eq!(
             parse_github_remote("git@github.com:stevedores-org/aivcs.git"),
+            Some("stevedores-org/aivcs".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_github_remote_supports_rfc_ssh_url() {
+        // RFC-style SSH URL — some tools (and `git remote -v` output on
+        // certain Git versions / configs) emit this form. Slash separator
+        // after the hostname, unlike the SCP-style colon form.
+        assert_eq!(
+            parse_github_remote("ssh://git@github.com/stevedores-org/aivcs.git"),
+            Some("stevedores-org/aivcs".to_string())
+        );
+        assert_eq!(
+            parse_github_remote("ssh://git@github.com/stevedores-org/aivcs"),
             Some("stevedores-org/aivcs".to_string())
         );
     }

--- a/crates/aivcs-core/src/github.rs
+++ b/crates/aivcs-core/src/github.rs
@@ -62,17 +62,22 @@ impl GitHubClient {
         Ok(sha)
     }
 
-    /// Commit a single file to a specific branch.
+    /// Commit a single file to a specific branch. Returns the resulting commit SHA.
+    ///
+    /// Currently UTF-8 text only — octocrab's `create_file` takes `String`
+    /// content. Binary commits need a different API path; see the inline
+    /// reject in `cmd_pr_commit`.
     pub async fn commit_file(
         &self,
         branch: &str,
         path: &str,
         content: &str,
         message: &str,
-    ) -> Result<()> {
+    ) -> Result<String> {
         info!("Committing file '{}' to branch '{}'", path, branch);
 
-        self.octocrab
+        let update = self
+            .octocrab
             .repos(&self.owner, &self.repo)
             .create_file(path, message, content)
             .branch(branch)
@@ -80,7 +85,9 @@ impl GitHubClient {
             .await
             .context(format!("failed to commit file '{}'", path))?;
 
-        Ok(())
+        update.commit.sha.ok_or_else(|| {
+            anyhow::anyhow!("GitHub Contents API returned no commit SHA for '{}'", path)
+        })
     }
 
     /// Open a Pull Request and optionally request review from the Librarian Agent.


### PR DESCRIPTION
## Summary
Cheap+meaningful fixes from the [self-review of #207](https://github.com/stevedores-org/aivcs/pull/207#issuecomment). No happy-path behaviour change in either CLI verb; tightens unhappy paths and discovery surface.

### What's in
- **`commit_file` returns the commit SHA** (was `Result<()>`). `cmd_pr_commit` prints it on success — matches `cmd_pr_branch`, pipeable into the next step without a second branch-tip query.
- **Actionable error for binary inputs to `cmd_pr_commit`.** `tokio::fs::read` + explicit `str::from_utf8` validation names the file and the limitation. The previous `is not valid UTF-8` left operators guessing.
- **`parse_github_remote` accepts `ssh://git@github.com/...`** in addition to the SCP-style and HTTPS shapes. New tests cover both `.git`-suffixed and bare ssh:// inputs.
- **README documents the four `AIVCS_A2A_*` env vars** that `maybe_emit_code_committed_from_env` reads (`URL`, `METHOD`, `AGENT_ID`, `JOB_ID`) — they weren't in the env table before.
- **README calls out the synchronous-best-effort latency** for `snapshot`/`merge` A2A emission, so anyone tightening snapshot SLOs knows to pin `A2aRetryPolicy::default()`.

### What's deferred (filed as #210)
Proper binary commit support via `commit_file_bytes(&[u8])` — octocrab's `create_file` is text-only, so true binary support needs either a new path that bypasses it (manual `octocrab.put(...)` + base64) or replaces it. Filed as #210 because it's a non-trivial API change, not a follow-up nit.

## Diff shape
- `aivcs-core/src/github.rs`: `commit_file` signature + docstring.
- `aivcs-core/src/git.rs`: new ssh:// shape + test.
- `aivcs-cli/src/main.rs`: `cmd_pr_commit` async I/O + UTF-8 pre-flight + SHA print.
- `README.md`: env-var docs + latency callout + UTF-8 caveat.

## Test plan
- [x] `cargo check -p aivcs-cli` clean.
- [x] `cargo test -p aivcs-core --lib git::` → 7 pass (1 new: `parse_github_remote_supports_rfc_ssh_url`).
- [x] `cargo test -p aivcs-core --lib github::` → 5 pass (unchanged from #207).
- [ ] After deploy: `aivcs pr commit --file ./logo.png` returns the new actionable error (was `stream did not contain valid UTF-8`).
- [ ] `aivcs pr commit --file ./docs/example.md` prints the commit SHA in the success line.

## Follow-up
- #210: Binary file support in `commit_file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)