### PR TITLE
feat(pr): zero-touch pipeline for Epic #191

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,18 +148,33 @@ The JSON-RPC params contain the AIVCS commit hash. Snapshot events include the s
 }
 ```
 
-### GitHub Integration (`pr open`, `pr branch`, `pr commit`)
+### GitHub Integration (`pr open`, `pr branch`, `pr commit`, `pr pipeline`)
 
-Autonomous builder agents use the `pr` subcommands to branch, commit, and open Pull Requests via the GitHub API. Tokens are read from `GITHUB_TOKEN` (GitHub App installation token from ESO, or PAT for local dev).
+Autonomous builder agents use the `pr` subcommands to branch, commit, and open Pull Requests via the GitHub API. Tokens are read from `GITHUB_TOKEN` (GitHub App installation token from ESO) or `GITHUB_TOKEN_FILE` (Kubernetes secret volume mount).
 
 ```bash
 export GITHUB_TOKEN="<github-app-installation-token-or-pat>"
+# Or: export GITHUB_TOKEN_FILE="/var/run/secrets/github/token"
 export RELIC_LIBRARIAN_USERNAME="librarian-bot"
 
-# 1. Create a feature branch
-aivcs pr branch --name feature/my-change --base main --owner stevedores-org --repo aivcs
+# Zero-touch pipeline (branch → commit → CODE_COMMITTED → open PR)
+uv run aivcs pr pipeline \
+  --branch feature/my-change \
+  --base develop \
+  --path docs/example.md \
+  --file ./example.md \
+  --message "docs: add example" \
+  --title "feat: my change" \
+  --body "Summary of what changed." \
+  --owner stevedores-org \
+  --repo aivcs
 
-# 2. Commit a file to that branch
+# Or step-by-step:
+
+# 1. Create a feature branch
+aivcs pr branch --name feature/my-change --base develop --owner stevedores-org --repo aivcs
+
+# 2. Commit a file to that branch (emits CODE_COMMITTED when A2A URL is set)
 aivcs pr commit \
   --branch feature/my-change \
   --path docs/example.md \
@@ -173,7 +188,7 @@ aivcs pr open \
   --owner stevedores-org \
   --repo aivcs \
   --head feature/my-change \
-  --base main \
+  --base develop \
   --title "feat: my change" \
   --body  "Summary of what changed."
 ```
@@ -185,22 +200,25 @@ Required environment:
 | Variable | Description |
 |----------|-------------|
 | `GITHUB_TOKEN` | Bearer token for the GitHub API. Accepts a GitHub App installation token (preferred for autonomous Jobs) or a personal access token. |
+| `GITHUB_TOKEN_FILE` | Alternative token source: path to a file containing the bearer token (typical ESO secret volume mount). Used when `GITHUB_TOKEN` is unset or whitespace-only. |
 | `RELIC_LIBRARIAN_USERNAME` | GitHub username of the Librarian Agent. Required when `--librarian` is enabled (the default). Missing or whitespace-only values are rejected eagerly so the failure surfaces before the API call rather than mid-pipeline. |
 
 The `--librarian` flag defaults to `true`; pass `--librarian=false` to skip the review request in development or test contexts where the Librarian is not deployed.
 
+See [Zero-Touch PR Pipeline](docs/runbooks/zero-touch-pr-pipeline.md) for the full ADK Job runbook.
+
 #### A2A `CODE_COMMITTED` emission
 
-`aivcs snapshot` and `aivcs merge` emit a `CODE_COMMITTED` Agent-to-Agent event when the JSON-RPC URL is configured. The repo is resolved from `GITHUB_REPOSITORY` if set, otherwise from `git remote get-url origin`. The emission is no-op when the URL var is absent.
+`aivcs snapshot`, `aivcs merge`, `aivcs pr commit`, and `aivcs pr pipeline` emit a `CODE_COMMITTED` Agent-to-Agent event when the JSON-RPC URL is configured. The repo is resolved from `GITHUB_REPOSITORY` if set, otherwise from `git remote get-url origin`. The emission is no-op when the URL var is absent.
 
 | Variable | Description |
 |----------|-------------|
 | `AIVCS_A2A_JSONRPC_URL` | JSON-RPC endpoint to POST the event to. Absent or whitespace-only ⇒ no emission. |
-| `AIVCS_A2A_JSONRPC_METHOD` | Override the JSON-RPC method name. Defaults to `event.code_committed`. |
+| `AIVCS_A2A_JSONRPC_METHOD` | Override the JSON-RPC method name. Defaults to `a2a.events.publish`. |
 | `AIVCS_AGENT_ID` | Authoring agent identifier in the event payload. Falls back to the local commit author. |
 | `AIVCS_JOB_ID` | Optional job/run correlation ID. Whitespace-only values are dropped. |
 
-> ⚠️ The emission is awaited synchronously inside `snapshot` / `merge`. Transport failures retry per `A2aRetryPolicy::default()` before returning; the CLI blocks for that window. Pin the retry policy if you tighten snapshot-latency SLOs.
+> ⚠️ The emission is awaited synchronously inside `snapshot` / `merge` / `pr commit` / `pr pipeline`. Transport failures retry per `A2aRetryPolicy::default()` before returning; the CLI blocks for that window. Pin the retry policy if you tighten snapshot-latency SLOs.
 
 #### `pr commit` and file content
 
@@ -214,6 +232,7 @@ The `--librarian` flag defaults to `true`; pass `--librarian=false` to skip the 
 - [Local Development](docs/runbooks/local-development.md) — build, test, dev workflows
 - [Database Configuration](docs/runbooks/database-configuration.md) — in-memory, local, cloud setup
 - [CI Troubleshooting](docs/runbooks/ci-troubleshooting.md) — common failures, reproduce locally
+- [Zero-Touch PR Pipeline](docs/runbooks/zero-touch-pr-pipeline.md) — autonomous agent Jobs: branch, commit, PR, A2A
 
 ## Contributing
 

--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -333,6 +333,56 @@ enum PrAction {
         #[arg(long)]
         repo: String,
     },
+
+    /// Zero-touch pipeline: branch → commit → CODE_COMMITTED → open PR
+    ///
+    /// Runs the full autonomous builder flow in one invocation. Intended for
+    /// ephemeral ADK Agent Jobs that invoke `aivcs` via `uv`.
+    Pipeline {
+        /// Feature branch to create and commit to
+        #[arg(short, long)]
+        branch: String,
+
+        /// Base branch or ref
+        #[arg(short, long, default_value = "develop")]
+        base: String,
+
+        /// Repository-relative file path
+        #[arg(short, long)]
+        path: String,
+
+        /// Local file to upload
+        #[arg(short, long)]
+        file: PathBuf,
+
+        /// Commit message
+        #[arg(short, long)]
+        message: String,
+
+        /// Pull request title
+        #[arg(short, long)]
+        title: String,
+
+        /// Pull request body (markdown)
+        #[arg(short, long)]
+        body: String,
+
+        /// GitHub organization/owner
+        #[arg(long)]
+        owner: String,
+
+        /// GitHub repository name
+        #[arg(long)]
+        repo: String,
+
+        /// Request review from the Librarian Agent
+        #[arg(long, default_value_t = true)]
+        librarian: bool,
+
+        /// Skip branch creation (for retries when the branch already exists)
+        #[arg(long, default_value_t = false)]
+        skip_branch: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -597,6 +647,34 @@ async fn main() -> Result<()> {
                 owner,
                 repo,
             } => cmd_pr_commit(branch, path, message, file, owner, repo).await,
+            PrAction::Pipeline {
+                branch,
+                base,
+                path,
+                file,
+                message,
+                title,
+                body,
+                owner,
+                repo,
+                librarian,
+                skip_branch,
+            } => {
+                cmd_pr_pipeline(PrPipelineArgs {
+                    branch,
+                    base,
+                    path,
+                    file,
+                    message,
+                    title,
+                    body,
+                    owner,
+                    repo,
+                    librarian,
+                    skip_branch,
+                })
+                .await
+            }
         },
         Commands::Report { action } => match action {
             ReportAction::CrossOrg {
@@ -701,14 +779,88 @@ async fn cmd_pr_commit(
         .commit_file(&branch, &path, content, &message)
         .await?;
     println!("Committed '{path}' to branch '{branch}' ({sha})");
+
+    aivcs_core::maybe_emit_code_committed_from_env(
+        &branch,
+        &sha,
+        vec![path.clone()],
+        "github-pr-commit",
+    )
+    .await;
+
+    Ok(())
+}
+
+struct PrPipelineArgs {
+    branch: String,
+    base: String,
+    path: String,
+    file: PathBuf,
+    message: String,
+    title: String,
+    body: String,
+    owner: String,
+    repo: String,
+    librarian: bool,
+    skip_branch: bool,
+}
+
+async fn cmd_pr_pipeline(args: PrPipelineArgs) -> Result<()> {
+    let PrPipelineArgs {
+        branch,
+        base,
+        path,
+        file,
+        message,
+        title,
+        body,
+        owner,
+        repo,
+        librarian,
+        skip_branch,
+    } = args;
+
+    let client = github_client_from_env(owner.clone(), repo.clone())?;
+
+    if !skip_branch {
+        let sha = client.create_branch(&branch, &base).await?;
+        println!("Created branch '{branch}' from '{base}' ({sha})");
+    }
+
+    let bytes = tokio::fs::read(&file)
+        .await
+        .with_context(|| format!("Failed to read file for commit: {:?}", file))?;
+    let content = std::str::from_utf8(&bytes).map_err(|err| {
+        anyhow::anyhow!(
+            "File {file:?} is not valid UTF-8 ({err}). Binary file commits via `aivcs pr pipeline` are not yet supported."
+        )
+    })?;
+
+    let sha = client
+        .commit_file(&branch, &path, content, &message)
+        .await?;
+    println!("Committed '{path}' to branch '{branch}' ({sha})");
+
+    aivcs_core::maybe_emit_code_committed_from_env(
+        &branch,
+        &sha,
+        vec![path.clone()],
+        "github-pr-pipeline",
+    )
+    .await;
+
+    let pr_number = client
+        .open_pr(&title, &body, &branch, &base, librarian)
+        .await?;
+    println!("Successfully opened PR #{pr_number}");
+
     Ok(())
 }
 
 fn github_client_from_env(owner: String, repo: String) -> Result<aivcs_core::github::GitHubClient> {
-    use aivcs_core::github::GitHubClient;
+    use aivcs_core::github::{resolve_github_token, GitHubClient};
 
-    let token =
-        std::env::var("GITHUB_TOKEN").context("GITHUB_TOKEN environment variable is required")?;
+    let token = resolve_github_token()?;
     GitHubClient::new(token, owner, repo)
 }
 

--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -340,31 +340,31 @@ enum PrAction {
     /// ephemeral ADK Agent Jobs that invoke `aivcs` via `uv`.
     Pipeline {
         /// Feature branch to create and commit to
-        #[arg(short, long)]
+        #[arg(long)]
         branch: String,
 
         /// Base branch or ref
-        #[arg(short, long, default_value = "develop")]
+        #[arg(long, default_value = "develop")]
         base: String,
 
         /// Repository-relative file path
-        #[arg(short, long)]
+        #[arg(long)]
         path: String,
 
         /// Local file to upload
-        #[arg(short, long)]
+        #[arg(long)]
         file: PathBuf,
 
         /// Commit message
-        #[arg(short, long)]
+        #[arg(long)]
         message: String,
 
         /// Pull request title
-        #[arg(short, long)]
+        #[arg(long)]
         title: String,
 
         /// Pull request body (markdown)
-        #[arg(short, long)]
+        #[arg(long)]
         body: String,
 
         /// GitHub organization/owner
@@ -753,6 +753,19 @@ async fn cmd_pr_branch(name: String, base: String, owner: String, repo: String) 
     Ok(())
 }
 
+async fn read_utf8_file_for_github_commit(file: &PathBuf) -> Result<String> {
+    let bytes = tokio::fs::read(file)
+        .await
+        .with_context(|| format!("Failed to read file for commit: {:?}", file))?;
+    std::str::from_utf8(&bytes)
+        .map(|content| content.to_string())
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "File {file:?} is not valid UTF-8 ({err}). Binary file commits via GitHub Contents API are not yet supported."
+            )
+        })
+}
+
 async fn cmd_pr_commit(
     branch: String,
     path: String,
@@ -761,22 +774,12 @@ async fn cmd_pr_commit(
     owner: String,
     repo: String,
 ) -> Result<()> {
-    // Read as bytes + UTF-8 validate explicitly so the operator sees an
-    // actionable message for binary files instead of the opaque default
-    // ("stream did not contain valid UTF-8"). Binary commits would need
-    // a different code path through the Contents API — tracked separately.
-    let bytes = tokio::fs::read(&file)
-        .await
-        .with_context(|| format!("Failed to read file for commit: {:?}", file))?;
-    let content = std::str::from_utf8(&bytes).map_err(|err| {
-        anyhow::anyhow!(
-            "File {file:?} is not valid UTF-8 ({err}). Binary file commits via `aivcs pr commit` are not yet supported."
-        )
-    })?;
+    let content = read_utf8_file_for_github_commit(&file).await?;
+    let github_repo = format!("{owner}/{repo}");
 
     let client = github_client_from_env(owner, repo)?;
     let sha = client
-        .commit_file(&branch, &path, content, &message)
+        .commit_file(&branch, &path, &content, &message)
         .await?;
     println!("Committed '{path}' to branch '{branch}' ({sha})");
 
@@ -785,6 +788,7 @@ async fn cmd_pr_commit(
         &sha,
         vec![path.clone()],
         "github-pr-commit",
+        Some(&github_repo),
     )
     .await;
 
@@ -820,6 +824,7 @@ async fn cmd_pr_pipeline(args: PrPipelineArgs) -> Result<()> {
         skip_branch,
     } = args;
 
+    let github_repo = format!("{owner}/{repo}");
     let client = github_client_from_env(owner.clone(), repo.clone())?;
 
     if !skip_branch {
@@ -827,17 +832,10 @@ async fn cmd_pr_pipeline(args: PrPipelineArgs) -> Result<()> {
         println!("Created branch '{branch}' from '{base}' ({sha})");
     }
 
-    let bytes = tokio::fs::read(&file)
-        .await
-        .with_context(|| format!("Failed to read file for commit: {:?}", file))?;
-    let content = std::str::from_utf8(&bytes).map_err(|err| {
-        anyhow::anyhow!(
-            "File {file:?} is not valid UTF-8 ({err}). Binary file commits via `aivcs pr pipeline` are not yet supported."
-        )
-    })?;
+    let content = read_utf8_file_for_github_commit(&file).await?;
 
     let sha = client
-        .commit_file(&branch, &path, content, &message)
+        .commit_file(&branch, &path, &content, &message)
         .await?;
     println!("Committed '{path}' to branch '{branch}' ({sha})");
 
@@ -846,6 +844,7 @@ async fn cmd_pr_pipeline(args: PrPipelineArgs) -> Result<()> {
         &sha,
         vec![path.clone()],
         "github-pr-pipeline",
+        Some(&github_repo),
     )
     .await;
 
@@ -966,6 +965,7 @@ async fn cmd_snapshot(
         &commit_id.hash,
         vec![state_path.display().to_string()],
         author,
+        None,
     )
     .await;
 
@@ -1200,6 +1200,7 @@ async fn cmd_merge(
         &result.merge_commit_id.hash,
         Vec::new(),
         "agent-git",
+        None,
     )
     .await;
 

--- a/crates/aivcs-core/src/a2a.rs
+++ b/crates/aivcs-core/src/a2a.rs
@@ -150,11 +150,15 @@ impl Default for A2aRetryPolicy {
 ///
 /// No-op when the endpoint env var is unset. Transport failures are logged and
 /// retried but never propagated to callers.
+///
+/// `repo_override` supplies `owner/repo` when the caller knows the target repo
+/// (e.g. GitHub Contents API commits from Agent Jobs without a local git remote).
 pub async fn maybe_emit_code_committed_from_env(
     branch: &str,
     commit_sha: &str,
     changed_paths: Vec<String>,
     author: &str,
+    repo_override: Option<&str>,
 ) {
     let Some(endpoint) = std::env::var("AIVCS_A2A_JSONRPC_URL")
         .ok()
@@ -163,8 +167,10 @@ pub async fn maybe_emit_code_committed_from_env(
         return;
     };
 
-    let repo =
-        crate::git::detect_github_repository().unwrap_or_else(|| "unknown/unknown".to_string());
+    let repo = repo_override
+        .map(str::to_string)
+        .or_else(crate::git::detect_github_repository)
+        .unwrap_or_else(|| "unknown/unknown".to_string());
     let method = std::env::var("AIVCS_A2A_JSONRPC_METHOD")
         .unwrap_or_else(|_| DEFAULT_A2A_METHOD.to_string());
     let authoring_agent_id = std::env::var("AIVCS_AGENT_ID").unwrap_or_else(|_| author.to_string());

--- a/crates/aivcs-core/src/github.rs
+++ b/crates/aivcs-core/src/github.rs
@@ -15,7 +15,7 @@ pub struct GitHubClient {
 }
 
 impl GitHubClient {
-    /// Create a new GitHub client using a personal access token.
+    /// Create a new GitHub client using a bearer token (PAT or GitHub App installation token).
     pub fn new(token: String, owner: String, repo: String) -> Result<Self> {
         let octocrab = Octocrab::builder()
             .personal_token(token)
@@ -159,6 +159,33 @@ impl GitHubClient {
     }
 }
 
+/// Resolve a GitHub bearer token for autonomous agent Jobs.
+///
+/// Prefers `GITHUB_TOKEN` (typical ESO projected env var). Falls back to
+/// `GITHUB_TOKEN_FILE` (Kubernetes secret volume mount path) so tokens never
+/// need to be written to shell history.
+pub fn resolve_github_token() -> Result<String> {
+    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+        let trimmed = token.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+
+    if let Ok(path) = std::env::var("GITHUB_TOKEN_FILE") {
+        let content = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read GITHUB_TOKEN_FILE at '{path}'"))?;
+        let trimmed = content.trim();
+        anyhow::ensure!(
+            !trimmed.is_empty(),
+            "GITHUB_TOKEN_FILE at '{path}' is empty"
+        );
+        return Ok(trimmed.to_string());
+    }
+
+    anyhow::bail!("GITHUB_TOKEN or GITHUB_TOKEN_FILE must be set for GitHub API access")
+}
+
 /// Validate the raw `RELIC_LIBRARIAN_USERNAME` env-var lookup result.
 ///
 /// Split out so the validation contract can be unit-tested without an HTTP
@@ -242,5 +269,91 @@ mod tests {
             !rendered.contains("must be set"),
             "non-UTF-8 error must not claim the variable is unset, got: {rendered}"
         );
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            // SAFETY: tests run serially within this module; each guard restores on drop.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_github_token_prefers_env_var() {
+        let _token = EnvGuard::set("GITHUB_TOKEN", "ghp_from_env");
+        let _file = EnvGuard::set("GITHUB_TOKEN_FILE", "/should/not/read");
+
+        let token = resolve_github_token().unwrap();
+        assert_eq!(token, "ghp_from_env");
+    }
+
+    #[test]
+    fn resolve_github_token_reads_file_when_env_empty() {
+        let _token = EnvGuard::set("GITHUB_TOKEN", "   ");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("token");
+        std::fs::write(&path, "ghp_from_file\n").unwrap();
+        let _file = EnvGuard::set("GITHUB_TOKEN_FILE", path.to_str().unwrap());
+
+        let token = resolve_github_token().unwrap();
+        assert_eq!(token, "ghp_from_file");
+    }
+
+    #[test]
+    fn resolve_github_token_missing_both_is_rejected() {
+        let _token = EnvUnsetGuard::unset("GITHUB_TOKEN");
+        let _file = EnvUnsetGuard::unset("GITHUB_TOKEN_FILE");
+
+        let err = resolve_github_token().unwrap_err();
+        assert!(
+            format!("{err:#}").contains("GITHUB_TOKEN or GITHUB_TOKEN_FILE"),
+            "expected missing-token error, got: {err:#}"
+        );
+    }
+
+    struct EnvUnsetGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvUnsetGuard {
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvUnsetGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
     }
 }

--- a/crates/aivcs-core/src/github.rs
+++ b/crates/aivcs-core/src/github.rs
@@ -298,39 +298,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn resolve_github_token_prefers_env_var() {
-        let _token = EnvGuard::set("GITHUB_TOKEN", "ghp_from_env");
-        let _file = EnvGuard::set("GITHUB_TOKEN_FILE", "/should/not/read");
-
-        let token = resolve_github_token().unwrap();
-        assert_eq!(token, "ghp_from_env");
-    }
-
-    #[test]
-    fn resolve_github_token_reads_file_when_env_empty() {
-        let _token = EnvGuard::set("GITHUB_TOKEN", "   ");
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("token");
-        std::fs::write(&path, "ghp_from_file\n").unwrap();
-        let _file = EnvGuard::set("GITHUB_TOKEN_FILE", path.to_str().unwrap());
-
-        let token = resolve_github_token().unwrap();
-        assert_eq!(token, "ghp_from_file");
-    }
-
-    #[test]
-    fn resolve_github_token_missing_both_is_rejected() {
-        let _token = EnvUnsetGuard::unset("GITHUB_TOKEN");
-        let _file = EnvUnsetGuard::unset("GITHUB_TOKEN_FILE");
-
-        let err = resolve_github_token().unwrap_err();
-        assert!(
-            format!("{err:#}").contains("GITHUB_TOKEN or GITHUB_TOKEN_FILE"),
-            "expected missing-token error, got: {err:#}"
-        );
-    }
-
     struct EnvUnsetGuard {
         key: &'static str,
         previous: Option<String>,
@@ -354,6 +321,37 @@ mod tests {
                     None => std::env::remove_var(self.key),
                 }
             }
+        }
+    }
+
+    #[test]
+    fn resolve_github_token_scenarios() {
+        // Prefer env var over file path.
+        {
+            let _token = EnvGuard::set("GITHUB_TOKEN", "ghp_from_env");
+            let _file = EnvGuard::set("GITHUB_TOKEN_FILE", "/should/not/read");
+            assert_eq!(resolve_github_token().unwrap(), "ghp_from_env");
+        }
+
+        // Fall back to file when env var is whitespace-only.
+        {
+            let _token = EnvGuard::set("GITHUB_TOKEN", "   ");
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("token");
+            std::fs::write(&path, "ghp_from_file\n").unwrap();
+            let _file = EnvGuard::set("GITHUB_TOKEN_FILE", path.to_str().unwrap());
+            assert_eq!(resolve_github_token().unwrap(), "ghp_from_file");
+        }
+
+        // Reject when neither source is usable.
+        {
+            let _token = EnvUnsetGuard::unset("GITHUB_TOKEN");
+            let _file = EnvUnsetGuard::unset("GITHUB_TOKEN_FILE");
+            let err = resolve_github_token().unwrap_err();
+            assert!(
+                format!("{err:#}").contains("GITHUB_TOKEN or GITHUB_TOKEN_FILE"),
+                "expected missing-token error, got: {err:#}"
+            );
         }
     }
 }

--- a/docs/runbooks/zero-touch-pr-pipeline.md
+++ b/docs/runbooks/zero-touch-pr-pipeline.md
@@ -1,0 +1,79 @@
+# Zero-Touch PR Pipeline
+
+Epic: [stevedores-org/aivcs#191](https://github.com/stevedores-org/aivcs/issues/191)
+
+Autonomous builder agents running in ephemeral ADK Jobs use `aivcs` (via `uv`) to branch, commit, open Pull Requests, and emit `CODE_COMMITTED` A2A events — without a local git checkout or human in the loop.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant Job as ADK Agent Job
+    participant AIVCS as aivcs (uv)
+    participant GH as GitHub API
+    participant Lib as Librarian Agent
+    participant A2A as A2A JSON-RPC
+
+    Job->>AIVCS: pr pipeline (or branch → commit → open)
+    AIVCS->>GH: create branch
+    AIVCS->>GH: commit file (Contents API)
+    AIVCS->>A2A: CODE_COMMITTED (if URL configured)
+    AIVCS->>GH: open PR
+    AIVCS->>GH: request review (Librarian)
+    GH-->>Lib: review requested
+```
+
+## Single-command path
+
+```bash
+uv run aivcs pr pipeline \
+  --branch "feat/my-change" \
+  --base develop \
+  --path docs/example.md \
+  --file ./example.md \
+  --message "docs: add example" \
+  --title "feat: my change" \
+  --body "Closes stevedores-org/aivcs#191" \
+  --owner stevedores-org \
+  --repo aivcs
+```
+
+Use `--skip-branch` when retrying after a partial run where the branch already exists.
+
+## Step-by-step path
+
+Same as the README GitHub Integration section:
+
+1. `aivcs pr branch`
+2. `aivcs pr commit` — emits `CODE_COMMITTED` when `AIVCS_A2A_JSONRPC_URL` is set
+3. `aivcs pr open` — requests Librarian review by default
+
+## Required environment
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_TOKEN` | GitHub App installation token (preferred). Projected by ESO from a Kubernetes Secret. |
+| `GITHUB_TOKEN_FILE` | Alternative: path to a mounted token file (e.g. `/var/run/secrets/github/token`). Used when `GITHUB_TOKEN` is unset or whitespace-only. |
+| `RELIC_LIBRARIAN_USERNAME` | GitHub username of the Librarian Agent. Required when `--librarian` is enabled (default). |
+| `AIVCS_A2A_JSONRPC_URL` | JSON-RPC endpoint for A2A events. Absent ⇒ `CODE_COMMITTED` emission is skipped (no-op). |
+| `AIVCS_AGENT_ID` | Authoring agent ID in the event payload. Falls back to a pipeline-specific default. |
+| `AIVCS_JOB_ID` | Optional run correlation ID. |
+| `GITHUB_REPOSITORY` | `owner/repo` for the `CODE_COMMITTED` payload. Set in CI/Jobs when no local git remote exists. |
+
+## ESO + Workload Identity (task 2.2)
+
+GitHub App tokens are minted by External Secrets Operator and projected into Agent Job pods. Until the crossplane-heaven GitHub App minter lands ([crossplane-heaven#6](https://github.com/stevedores-org/crossplane-heaven/issues/6)), mount the token as either:
+
+- **`GITHUB_TOKEN`** — ESO `dataFrom` → env var, or
+- **`GITHUB_TOKEN_FILE`** — secret volume mount at a stable path
+
+`aivcs` reads `GITHUB_TOKEN` first, then falls back to the file.
+
+## Librarian review
+
+Every PR opened via `aivcs pr open` or `aivcs pr pipeline` requests review from the Librarian by default. Pass `--librarian=false` only in local dev or test contexts where the Librarian is not deployed.
+
+## Related issues
+
+- [#192](https://github.com/stevedores-org/aivcs/issues/192) — `CODE_COMMITTED` A2A event schema
+- [crossplane-heaven#6](https://github.com/stevedores-org/crossplane-heaven/issues/6) — ESO GitHub App token minter


### PR DESCRIPTION
## Summary

Completes the remaining in-repo work for [Epic #191 — Zero-touch PR pipeline](https://github.com/stevedores-org/aivcs/issues/191):

- **`aivcs pr pipeline`** — single command for ADK Agent Jobs: create branch → commit via GitHub Contents API → emit `CODE_COMMITTED` → open PR with Librarian review
- **`GITHUB_TOKEN_FILE`** — read bearer tokens from ESO/Kubernetes secret volume mounts when `GITHUB_TOKEN` is unset (prep for task 2.2 / crossplane-heaven#6)
- **`aivcs pr commit`** — now emits `CODE_COMMITTED` when `AIVCS_A2A_JSONRPC_URL` is configured (acceptance criterion: every commit fires the event)
- **Runbook** — `docs/runbooks/zero-touch-pr-pipeline.md` documents the full autonomous flow, env vars, and ESO integration

## Test plan

- [x] `cargo test -p aivcs-core github::` — token resolution + librarian username validation
- [x] `cargo clippy -p aivcs-core -p aivcs-cli -- -D warnings`
- [x] pre-commit local-ci (fmt, clippy) passed
- [ ] CI green on PR
- [ ] Manual smoke: `aivcs pr pipeline --help` renders expected flags

Closes #191


Made with [Cursor](https://cursor.com)