### PR TITLE
fix(lci): skip cache entry when file read fails mid-hash

### DIFF
--- a/tools/lci/cache.go
+++ b/tools/lci/cache.go
@@ -200,8 +200,13 @@ func filesystemSourceHash(root string) (string, error) {
 					continue
 				}
 				h := sha256.New()
-				io.Copy(h, f)
+				_, copyErr := io.Copy(h, f)
 				f.Close()
+				if copyErr != nil {
+					// Skip on read failure — a partial hash would silently
+					// invalidate the cache key for this file's content.
+					continue
+				}
 				results <- result{path: path, hash: h.Sum(nil)}
 			}
 		}()


### PR DESCRIPTION
## Problem

In `tools/lci/cache.go` the parallel hashing worker called `io.Copy(h, f)` and discarded the error. On a mid-read failure (transient I/O error, file truncated during walk, etc.) the worker would still push the *partial* hash into the results channel. That partial hash was then folded into the per-stage cache key as if it were the file's real content.

Two consequences:

- If the same read failure recurs deterministically, the cache locks in a wrong-but-stable hash and may return stale hits.
- Even for transient failures, the recorded hash for that run is not actually a function of the file content, so subsequent runs that succeed against the same file yield a different hash for reasons unrelated to source changes — cache thrash.

## Fix

Capture `io.Copy`'s error. On error, log nothing and skip pushing this file's result; the next run will rehash. The cache key is then derived only from files that were fully read in this run.

## Test plan

- [x] `go test ./tools/lci/...` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)