### PR TITLE
fix(publish-gate): report violation when VersionBump operands fail to parse

### DIFF
--- a/crates/aivcs-core/src/publish_gate.rs
+++ b/crates/aivcs-core/src/publish_gate.rs
@@ -231,8 +231,30 @@ fn check_rule(rule: &PublishRule, candidate: &PublishCandidate) -> Option<Publis
                 Some(l) if !l.is_empty() => l,
                 _ => return None, // no previous → skip
             };
-            let current = Semver::parse(current_label)?;
-            let previous = Semver::parse(prev_label)?;
+            let current = match Semver::parse(current_label) {
+                Some(s) => s,
+                None => {
+                    return Some(PublishViolation {
+                        rule: rule.clone(),
+                        reason: format!(
+                            "version '{}' is not valid semver (cannot compare to previous '{}')",
+                            current_label, prev_label,
+                        ),
+                    });
+                }
+            };
+            let previous = match Semver::parse(prev_label) {
+                Some(s) => s,
+                None => {
+                    return Some(PublishViolation {
+                        rule: rule.clone(),
+                        reason: format!(
+                            "previous_version '{}' is not valid semver (cannot compare to '{}')",
+                            prev_label, current_label,
+                        ),
+                    });
+                }
+            };
             if current.cmp_version(&previous) != std::cmp::Ordering::Greater {
                 Some(PublishViolation {
                     rule: rule.clone(),

--- a/crates/aivcs-core/tests/publish_gate.rs
+++ b/crates/aivcs-core/tests/publish_gate.rs
@@ -115,7 +115,10 @@ fn version_bump_rejects_unparseable_previous() {
     };
     let c = candidate(Some("1.0.0"), Some("not-a-version"), &[], None, "abc");
     let v = evaluate_publish_gate(&rs, &c);
-    assert!(!v.passed, "unparseable previous_version must not silently pass");
+    assert!(
+        !v.passed,
+        "unparseable previous_version must not silently pass"
+    );
     assert!(v
         .violations
         .iter()
@@ -130,7 +133,10 @@ fn version_bump_rejects_unparseable_current() {
     };
     let c = candidate(Some("not-a-version"), Some("1.0.0"), &[], None, "abc");
     let v = evaluate_publish_gate(&rs, &c);
-    assert!(!v.passed, "unparseable version_label must not silently pass VersionBump");
+    assert!(
+        !v.passed,
+        "unparseable version_label must not silently pass VersionBump"
+    );
     assert!(v
         .violations
         .iter()

--- a/crates/aivcs-core/tests/publish_gate.rs
+++ b/crates/aivcs-core/tests/publish_gate.rs
@@ -107,6 +107,36 @@ fn version_bump_skipped_no_previous() {
     assert!(v.passed);
 }
 
+#[test]
+fn version_bump_rejects_unparseable_previous() {
+    let rs = PublishRuleSet {
+        rules: vec![PublishRule::VersionBump],
+        fail_fast: false,
+    };
+    let c = candidate(Some("1.0.0"), Some("not-a-version"), &[], None, "abc");
+    let v = evaluate_publish_gate(&rs, &c);
+    assert!(!v.passed, "unparseable previous_version must not silently pass");
+    assert!(v
+        .violations
+        .iter()
+        .any(|viol| matches!(&viol.rule, PublishRule::VersionBump)));
+}
+
+#[test]
+fn version_bump_rejects_unparseable_current() {
+    let rs = PublishRuleSet {
+        rules: vec![PublishRule::VersionBump],
+        fail_fast: false,
+    };
+    let c = candidate(Some("not-a-version"), Some("1.0.0"), &[], None, "abc");
+    let v = evaluate_publish_gate(&rs, &c);
+    assert!(!v.passed, "unparseable version_label must not silently pass VersionBump");
+    assert!(v
+        .violations
+        .iter()
+        .any(|viol| matches!(&viol.rule, PublishRule::VersionBump)));
+}
+
 // ---- UniqueVersion ----
 
 #[test]


### PR DESCRIPTION
## Problem

`crates/aivcs-core/src/publish_gate.rs` evaluates the `VersionBump` rule by parsing both the current and previous version strings into `Semver`:

\`\`\`rust
let current = Semver::parse(current_label)?;
let previous = Semver::parse(prev_label)?;
\`\`\`

`check_rule` returns `Option<PublishViolation>`, where `None` means *no violation*. The `?` operator on a failed parse therefore returns `None` from `check_rule` — i.e. the rule **passes** when an operand can't be parsed. Consequences:

- An unparseable `previous_version` (e.g. "broken-1.2", "v2.0.0", or trailing whitespace not handled by `Semver::parse`) silently passes the gate.
- An unparseable `version_label` also silently passes `VersionBump`. `SemverFormat` would catch this *if* it's enabled, but `VersionBump` shouldn't depend on rule ordering.

## Fix

Replace the `?` with explicit `match` arms that return a `PublishViolation` explaining which operand failed to parse.

## Tests

Two new cases in `crates/aivcs-core/tests/publish_gate.rs`:
- `version_bump_rejects_unparseable_previous`
- `version_bump_rejects_unparseable_current`

\`\`\`
test result: ok. 17 passed; 0 failed
\`\`\`

## Test plan

- [x] `cargo test -p aivcs-core --test publish_gate` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)