### PR TITLE
fix(cli): warn instead of silently swallowing --no-cache and --fix

### DIFF
--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -1816,14 +1816,10 @@ async fn cmd_ci_run(
     fix: bool,
 ) -> Result<()> {
     if no_cache {
-        eprintln!(
-            "warning: --no-cache is not yet implemented; proceeding without caching changes"
-        );
+        eprintln!("warning: --no-cache is not yet implemented; proceeding without caching changes");
     }
     if fix {
-        eprintln!(
-            "warning: --fix is not yet implemented; stages will run in check-only mode"
-        );
+        eprintln!("warning: --fix is not yet implemented; stages will run in check-only mode");
     }
 
     // Get git SHA

--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -1812,9 +1812,20 @@ async fn cmd_diff_runs(ledger: &dyn RunLedger, id_a: &str, id_b: &str) -> Result
 async fn cmd_ci_run(
     workspace: &PathBuf,
     stages_str: &str,
-    _no_cache: bool,
-    _fix: bool,
+    no_cache: bool,
+    fix: bool,
 ) -> Result<()> {
+    if no_cache {
+        eprintln!(
+            "warning: --no-cache is not yet implemented; proceeding without caching changes"
+        );
+    }
+    if fix {
+        eprintln!(
+            "warning: --fix is not yet implemented; stages will run in check-only mode"
+        );
+    }
+
     // Get git SHA
     let git_sha = if let Ok(output) = std::process::Command::new("git")
         .args(["rev-parse", "HEAD"])


### PR DESCRIPTION
## Problem

\`aivcs ci run\` exposes two boolean flags:

\`\`\`rust
#[arg(long)] no_cache: bool,
#[arg(long)] fix: bool,
\`\`\`

These are passed into \`cmd_ci_run\` as \`_no_cache: bool\` and \`_fix: bool\` — i.e. parameters explicitly named to suppress unused-variable warnings. Nothing in the body reads them. A user running \`aivcs ci run --fix\` gets:

- exit code 0 if the (check-mode) pipeline passes,
- "All checks passed!" printed,
- no auto-repair attempted, no indication the flag did nothing.

That's a silent false-success. Worse for \`--no-cache\`: a user trying to bypass a stale cache won't know they didn't.

## Fix

Until the actual behavior lands, emit a one-line warning to stderr when either flag is set. Keeps the CLI surface backwards-compatible (scripts that already pass these flags continue to run) but makes the no-op visible.

\`\`\`
warning: --no-cache is not yet implemented; proceeding without caching changes
warning: --fix is not yet implemented; stages will run in check-only mode
\`\`\`

## Notes

I considered \`anyhow::bail!\` instead of a warning, but that would break any pipelines/scripts already passing these flags expecting them to be accepted. A warning is the smallest behavior change that removes the false-success.

## Test plan

- [x] \`cargo check -p aivcs-cli\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)