### PR TITLE
fix(semantic-merge): give recency_score real discriminative power

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4018,6 +4018,7 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "oxidized-state",
  "serde",
  "serde_json",

--- a/crates/semantic-rag-merge/Cargo.toml
+++ b/crates/semantic-rag-merge/Cargo.toml
@@ -32,6 +32,7 @@ tracing.workspace = true
 
 # Utilities
 uuid.workspace = true
+chrono.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/semantic-rag-merge/src/lib.rs
+++ b/crates/semantic-rag-merge/src/lib.rs
@@ -189,8 +189,20 @@ pub async fn resolve_conflict_state(
 /// 2. Recency (newer memories reflect latest state)
 /// 3. Metadata richness (more context is better)
 fn conflict_score(record: &MemoryRecord) -> f32 {
+    conflict_score_at(record, chrono::Utc::now())
+}
+
+/// Same as `conflict_score` but with the "now" reference injected, so the
+/// function is pure and unit-testable.
+fn conflict_score_at(record: &MemoryRecord, now: chrono::DateTime<chrono::Utc>) -> f32 {
     let length_score = (record.content.len() as f32).ln().max(0.0);
-    let recency_score = record.created_at.timestamp() as f32 / 1_000_000_000.0;
+    // Recency: bounded in [0, 1], decays with age. ~1.0 for "just now",
+    // ~0.5 at 30 days, ~0.1 at ~9 months. The previous version divided a
+    // raw Unix-seconds timestamp by 1e9, which produced a near-constant
+    // ~1.7 for every recently-created memory — i.e. zero discriminative
+    // power between any two candidates.
+    let age_secs = (now - record.created_at).num_seconds().max(0) as f32;
+    let recency_score = 1.0 / (1.0 + age_secs / (30.0 * 86_400.0));
     let meta_score = metadata_field_count(&record.metadata) as f32;
     length_score + recency_score + meta_score
 }
@@ -361,6 +373,47 @@ mod tests {
 
         assert_eq!(delta.conflicts.len(), 1);
         assert_eq!(delta.conflicts[0].key, "conflict-key");
+    }
+
+    #[test]
+    fn test_recency_discriminates_between_memories() {
+        // Two memories with identical content/metadata but different ages.
+        // Without the fix, recency_score divides Unix seconds by 1e9, so
+        // any two recent memories score ~equally on recency. With the fix,
+        // a newer memory must score strictly higher than an older one.
+        let now = chrono::Utc::now();
+        let old_record = MemoryRecord {
+            id: None,
+            commit_id: "c".to_string(),
+            key: "k".to_string(),
+            content: "same".to_string(),
+            embedding: None,
+            metadata: serde_json::Value::Null,
+            created_at: now - chrono::Duration::days(60),
+        };
+        let new_record = MemoryRecord {
+            id: None,
+            commit_id: "c".to_string(),
+            key: "k".to_string(),
+            content: "same".to_string(),
+            embedding: None,
+            metadata: serde_json::Value::Null,
+            created_at: now,
+        };
+
+        let old_score = conflict_score_at(&old_record, now);
+        let new_score = conflict_score_at(&new_record, now);
+
+        assert!(
+            new_score > old_score,
+            "newer memory must score higher; got new={new_score} old={old_score}",
+        );
+        // And the gap should be meaningful (≥0.3, since recency is bounded
+        // in [0, 1] and 60 days ago gives ~0.33 while now gives ~1.0).
+        assert!(
+            (new_score - old_score) > 0.3,
+            "recency gap too small: new={new_score} old={old_score}",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

\`conflict_score\` in \`crates/semantic-rag-merge/src/lib.rs\` is used to pick a winner when two branches disagree about a memory value. It combines three signals: content length, recency, and metadata richness. The recency formula was:

\`\`\`rust
let recency_score = record.created_at.timestamp() as f32 / 1_000_000_000.0;
\`\`\`

For any memory created in the past decade, \`timestamp()\` returns ~1.5e9–1.7e9. Dividing by 1e9 produces a near-constant ~1.5–1.7. So:

- Two memories created seconds apart differ in \`recency_score\` by ~5e-9. Noise.
- Two memories created 60 *days* apart differ by ~5e-3. Still noise next to length_score (~1–5) and meta_score (~0–5).

i.e. the "recency" signal was effectively a constant baseline that added the same offset to both candidates — no discriminative power at all. The signal listed in the function docstring did not exist in the implementation.

## Fix

Replace with a bounded exponential-ish decay relative to "now":

\`\`\`rust
let age_secs = (now - record.created_at).num_seconds().max(0) as f32;
let recency_score = 1.0 / (1.0 + age_secs / (30.0 * 86_400.0));
\`\`\`

- ~1.0 for "just now"
- ~0.5 at 30 days
- ~0.1 at ~9 months
- Strictly monotonically decreasing in age
- Bounded in [0, 1], comparable in magnitude to the other two signals

Refactored into a pure helper \`conflict_score_at(record, now)\` so the scoring can be unit-tested without leaning on \`Utc::now()\`. \`conflict_score(record)\` is now a one-liner that calls it with \`Utc::now()\`.

## Tests

New test \`test_recency_discriminates_between_memories\` verifies that two otherwise-identical memories created 60 days apart now have a measurable score gap.

\`\`\`
test result: ok. 5 passed; 0 failed
\`\`\`

The existing \`test_arbiter_resolves_value_conflict_based_on_cot\` and \`test_merge_synthesizes_two_memories_into_one_new_commit\` still pass — they relied on content length to break ties, which the new recency function doesn't disturb when both memories are equally recent.

## Test plan

- [x] \`cargo test -p semantic-rag-merge --lib\` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)