### PR TITLE
feat(bench): hyperfine harness for aivcs-cli hot paths

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,66 @@
+name: bench
+
+# Manual trigger only — bench wall-clock is sensitive to runner contention,
+# so we don't burn it on every PR. Operators dispatch this to capture a
+# baseline or to A/B a candidate fix.
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: "hyperfine --runs count"
+        required: false
+        default: "10"
+      warmup:
+        description: "hyperfine --warmup count"
+        required: false
+        default: "3"
+
+concurrency:
+  group: bench-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: short
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "workspace"
+          cache-targets: true
+          save-if: false
+
+      - name: Install hyperfine
+        uses: taiki-e/install-action@v2
+        with:
+          tool: hyperfine
+
+      - name: Build release binary
+        run: make bench-build
+
+      - name: Run bench
+        env:
+          BENCH_OUT: bench-results
+          BENCH_RUNS: ${{ inputs.runs }}
+          BENCH_WARMUP: ${{ inputs.warmup }}
+        run: make bench
+
+      - name: Upload markdown summaries
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aivcs-cli-bench-${{ github.run_id }}
+          path: bench-results/
+          if-no-files-found: warn

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lci-build lci lci-install hooks
+.PHONY: lci-build lci lci-install hooks bench bench-build
 
 # Build the local CI runner
 lci-build:
@@ -13,6 +13,16 @@ lci-install: lci-build
 	mkdir -p $(HOME)/.local/bin
 	cp tools/lci/lci $(HOME)/.local/bin/local-ci
 	@echo "Installed local-ci to ~/.local/bin/local-ci"
+
+# Build the release binary the bench harness drives. Separate target so CI can
+# cache the build and only re-bench on rebuild.
+bench-build:
+	cargo build --release -p aivcs-cli
+
+# Wall-clock bench of aivcs-cli hot paths via hyperfine.
+# See tools/bench/aivcs-cli.sh for env overrides (AIVCS, BENCH_OUT, BENCH_RUNS).
+bench: bench-build
+	./tools/bench/aivcs-cli.sh
 
 # Install git pre-commit hook
 hooks:

--- a/tools/bench/aivcs-cli.sh
+++ b/tools/bench/aivcs-cli.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# tools/bench/aivcs-cli.sh — wall-clock bench of aivcs-cli hot paths via hyperfine.
+#
+# Scenarios:
+#   1. cold init+snapshot — full process boot + DB init + first I/O
+#   2. warm snapshot      — repeat snapshots into an already-initialised dir
+#   3. pr-note            — generate the PR linkage block (issue #220 Phase 0 path)
+#
+# Env overrides:
+#   AIVCS         path to the aivcs binary (default: target/release/aivcs from repo root)
+#   BENCH_OUT     if set, hyperfine markdown summaries are written into this dir
+#   BENCH_WARMUP  hyperfine --warmup count (default: 3)
+#   BENCH_RUNS    hyperfine --runs count (default: 10)
+#
+# Exit codes:
+#   0 ok / 1 setup error / 2 hyperfine missing / 3 binary missing
+set -euo pipefail
+
+if ! command -v hyperfine >/dev/null 2>&1; then
+  echo "error: hyperfine not found on PATH" >&2
+  echo "       install via: brew install hyperfine   (macOS)" >&2
+  echo "                    cargo install hyperfine  (any)"   >&2
+  exit 2
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+AIVCS="${AIVCS:-$REPO_ROOT/target/release/aivcs}"
+WARMUP="${BENCH_WARMUP:-3}"
+RUNS="${BENCH_RUNS:-10}"
+
+if [[ ! -x "$AIVCS" ]]; then
+  echo "error: aivcs binary not found or not executable: $AIVCS" >&2
+  echo "       build with: cargo build --release -p aivcs-cli" >&2
+  exit 3
+fi
+
+WORK="$(mktemp -d -t aivcs-bench.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Each scenario gets its own subdir. Hyperfine commands run in WORK by default,
+# so we cd into the scenario dir via the shell.
+mkdir -p "$WORK/cold" "$WORK/warm" "$WORK/note"
+
+# All scenarios assume a real git repo under their cwd so `git rev-parse HEAD`
+# succeeds — this is the realistic case and it exercises the subprocess spawns
+# the code review flagged.
+seed_git_repo() {
+  local dir="$1"
+  (
+    cd "$dir"
+    git init --quiet
+    git config user.email "bench@aivcs.invalid"
+    git config user.name  "bench"
+    echo "seed" > seed.txt
+    git add seed.txt
+    git commit --quiet -m "seed"
+  )
+}
+
+seed_git_repo "$WORK/cold"
+seed_git_repo "$WORK/warm"
+seed_git_repo "$WORK/note"
+
+# Pre-seed warm/note with one init+snapshot so the bench measures only the
+# repeated path, not the one-shot setup.
+(
+  cd "$WORK/warm"
+  echo '{"step":0}' > state.json
+  "$AIVCS" init . >/dev/null
+  "$AIVCS" snapshot --state state.json --message seed --author bench --branch main >/dev/null
+)
+(
+  cd "$WORK/note"
+  echo '{"step":0}' > state.json
+  "$AIVCS" init . >/dev/null
+  "$AIVCS" snapshot --state state.json --message seed --author bench --branch main >/dev/null
+)
+
+OUT_DIR=""
+if [[ -n "${BENCH_OUT:-}" ]]; then
+  mkdir -p "$BENCH_OUT"
+  OUT_DIR="$BENCH_OUT"
+fi
+
+export_args() {
+  local name="$1"
+  if [[ -n "$OUT_DIR" ]]; then
+    echo "--export-markdown $OUT_DIR/$name.md"
+  fi
+}
+
+echo "=== aivcs-cli bench ==="
+echo "binary : $AIVCS"
+echo "workdir: $WORK"
+echo "warmup : $WARMUP runs / measured: $RUNS"
+echo
+
+# --- 1. cold init+snapshot ---------------------------------------------------
+# --prepare wipes the .aivcs dir between runs so each iteration is truly cold.
+echo "--- scenario 1: cold init+snapshot ---"
+# shellcheck disable=SC2046
+hyperfine \
+  --warmup "$WARMUP" \
+  --runs "$RUNS" \
+  --command-name "cold init+snapshot" \
+  --prepare "rm -rf '$WORK/cold/.aivcs'" \
+  $(export_args cold-init-snapshot) \
+  "cd '$WORK/cold' && '$AIVCS' init . >/dev/null && echo '{\"step\":1}' > state.json && '$AIVCS' snapshot --state state.json --message bench --author bench --branch main >/dev/null"
+
+# --- 2. warm snapshot --------------------------------------------------------
+# No --prepare: each iteration writes a new commit into the existing DB. The
+# CAS dir grows linearly with RUNS+WARMUP — at the default 13 runs that's
+# ~13 small JSON files. Acceptable for a wall-clock bench; if RUNS climbs into
+# the hundreds, wipe the dir manually between bench invocations.
+echo
+echo "--- scenario 2: warm snapshot ---"
+# shellcheck disable=SC2046
+hyperfine \
+  --warmup "$WARMUP" \
+  --runs "$RUNS" \
+  --command-name "warm snapshot" \
+  $(export_args warm-snapshot) \
+  "cd '$WORK/warm' && '$AIVCS' snapshot --state state.json --message bench --author bench --branch main >/dev/null"
+
+# --- 3. pr-note --------------------------------------------------------------
+# Conditional: pr-note lands with issue #220 Phase 0 (PR #223). Skip cleanly
+# on binaries that predate it so the harness can ship before #223 merges.
+echo
+if "$AIVCS" pr-note --help >/dev/null 2>&1; then
+  echo "--- scenario 3: pr-note ---"
+  # shellcheck disable=SC2046
+  hyperfine \
+    --warmup "$WARMUP" \
+    --runs "$RUNS" \
+    --command-name "pr-note" \
+    $(export_args pr-note) \
+    "cd '$WORK/note' && '$AIVCS' pr-note --branch main >/dev/null"
+else
+  echo "--- scenario 3: pr-note --- (skipped: subcommand not in this build)"
+fi
+
+echo
+echo "done."
+if [[ -n "$OUT_DIR" ]]; then
+  echo "markdown summaries: $OUT_DIR/"
+fi


### PR DESCRIPTION
## Summary

- Adds `make bench` + `tools/bench/aivcs-cli.sh` driving three wall-clock scenarios via `hyperfine`: cold init+snapshot, warm snapshot, and `pr-note`
- Adds `.github/workflows/bench.yml` (workflow_dispatch only) that builds the release binary, runs the harness, and uploads markdown summaries as artifacts
- Targets the efficiency concerns surfaced in PR #223 review: git subprocess spawns on every snapshot/merge, serial DB lookups in `pr-note`, sync-await on the A2A emitter

## Why hyperfine, not Criterion

The surfaced inefficiencies are subprocess spawns (`git rev-parse`, `git remote`), serial awaits, and repeated I/O — wall-clock concerns that don't show up in tight microbenches. Pair with `cargo flamegraph` if a specific finding needs root-cause analysis.

## Test plan

- [x] `bash -n` syntax check on the script
- [x] `make -n bench` resolves the target chain
- [x] Script exits cleanly with hint when `hyperfine` is absent
- [x] `pr-note` scenario gracefully skips on builds without the subcommand (so this harness can ship before #223)
- [ ] Run `make bench` once locally with `hyperfine` installed and confirm three scenarios produce sane numbers
- [ ] Dispatch the CI workflow once to confirm the runner installs `hyperfine` via `taiki-e/install-action` and the artifact upload works

## Env overrides

- `AIVCS` — override the binary path (default: `target/release/aivcs`)
- `BENCH_OUT` — directory for markdown summaries (CI uses `bench-results/`)
- `BENCH_RUNS` / `BENCH_WARMUP` — tune statistical sample size

🤖 Generated with [Claude Code](https://claude.com/claude-code)