### PR TITLE
fix(dual-ledger): #[serde(default)] + reject detached HEAD (followup #223)

### DIFF
--- a/crates/aivcs-core/src/a2a.rs
+++ b/crates/aivcs-core/src/a2a.rs
@@ -35,8 +35,10 @@ pub struct CodeCommittedEvent {
     pub job_id: Option<String>,
     /// Event creation timestamp.
     pub timestamp: DateTime<Utc>,
-    /// Associated AIVCS commit ID, if present.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Associated AIVCS commit ID, if present. `serde(default)` so historical
+    /// payloads emitted before this field existed deserialize cleanly into the
+    /// current struct — `skip_serializing_if` alone is one-way.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub aivcs_commit_id: Option<String>,
 }
 

--- a/crates/aivcs-core/src/git.rs
+++ b/crates/aivcs-core/src/git.rs
@@ -114,6 +114,16 @@ pub fn detect_current_branch(repo_dir: &Path) -> Result<String> {
             "git rev-parse --abbrev-ref HEAD returned empty output".to_string(),
         ));
     }
+    // `git rev-parse --abbrev-ref HEAD` returns the literal string "HEAD" when
+    // the working tree is in detached-HEAD state (common in CI checkouts of
+    // tag/PR refs). Returning that to callers caused `aivcs pr-note` to look
+    // up a branch literally named "HEAD" in the DB and emit a confusing
+    // "Branch 'HEAD' not found" error. Surface the state explicitly instead.
+    if branch == "HEAD" {
+        return Err(AivcsError::GitError(
+            "git is in detached-HEAD state; pass --branch explicitly".to_string(),
+        ));
+    }
 
     Ok(branch)
 }
@@ -205,6 +215,24 @@ mod tests {
     fn parse_github_remote_rejects_invalid_values() {
         assert_eq!(parse_github_remote("https://gitlab.com/org/repo"), None);
         assert_eq!(parse_github_remote("not-a-url"), None);
+    }
+
+    #[test]
+    fn detect_current_branch_detached_head_returns_err() {
+        let repo = make_git_repo();
+        // Detach HEAD by checking out the commit SHA directly.
+        let sha = capture_head_sha(repo.path()).unwrap();
+        let status = Command::new("git")
+            .args(["checkout", "--detach", &sha])
+            .current_dir(repo.path())
+            .output()
+            .unwrap();
+        assert!(status.status.success(), "git checkout --detach failed");
+        let err = detect_current_branch(repo.path()).expect_err("detached HEAD must error");
+        assert!(
+            err.to_string().contains("detached-HEAD"),
+            "error must name the state: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Stacked on #223.** Closes 2 of the top crr findings; tight scope so the larger items (`aivcs_commit_id` plumbing on `cmd_pr_commit`/`pipeline`, the zero-SHA sentinel cluster, `commit_sha` semantic swap, `read_objective_id` CWD-relative path) can be addressed in dedicated follow-ups.

| # | Bug | Fix |
|---|-----|-----|
| 1 | Missing `#[serde(default)]` on `aivcs_commit_id` — historical payloads (no field) fail to deserialize | Added; `skip_serializing_if` alone is one-way |
| 2 | `detect_current_branch` returns literal `"HEAD"` in detached-HEAD state → confusing CI errors | Surfaces detached-HEAD explicitly: `"git is in detached-HEAD state; pass --branch explicitly"` |

## Tests

New `detect_current_branch_detached_head_returns_err` checks out a SHA directly via `git checkout --detach`, then asserts the helper errors with a message naming the state. All 330 `aivcs-core` tests pass; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)