### PR TITLE
feat: add require-local-ci gating and PR snapshot validation

### DIFF
--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -286,6 +286,10 @@ enum PrAction {
         /// Request review from the Librarian Agent
         #[arg(long, default_value_t = true)]
         librarian: bool,
+
+        /// Require local-ci validation before opening PR
+        #[arg(long, default_value_t = true)]
+        require_local_ci: bool,
     },
 
     /// Create a GitHub branch from a base ref
@@ -382,6 +386,17 @@ enum PrAction {
         /// Skip branch creation (for retries when the branch already exists)
         #[arg(long, default_value_t = false)]
         skip_branch: bool,
+
+        /// Require local-ci validation before opening PR
+        #[arg(long, default_value_t = true)]
+        require_local_ci: bool,
+    },
+
+    /// Verify aivcs-ci-snapshot against HEAD
+    VerifySnapshot {
+        /// Optional PR body text. If omitted, it will try to find it via GITHUB_EVENT_PATH.
+        #[arg(long)]
+        pr_body: Option<String>,
     },
 }
 
@@ -632,7 +647,8 @@ async fn main() -> Result<()> {
                 owner,
                 repo,
                 librarian,
-            } => cmd_pr_open(title, body, head, base, owner, repo, librarian).await,
+                require_local_ci,
+            } => cmd_pr_open(title, body, head, base, owner, repo, librarian, require_local_ci).await,
             PrAction::Branch {
                 name,
                 base,
@@ -659,6 +675,7 @@ async fn main() -> Result<()> {
                 repo,
                 librarian,
                 skip_branch,
+                require_local_ci,
             } => {
                 cmd_pr_pipeline(PrPipelineArgs {
                     branch,
@@ -672,9 +689,11 @@ async fn main() -> Result<()> {
                     repo,
                     librarian,
                     skip_branch,
+                    require_local_ci,
                 })
                 .await
             }
+            PrAction::VerifySnapshot { pr_body } => cmd_pr_verify_snapshot(pr_body).await,
         },
         Commands::Report { action } => match action {
             ReportAction::CrossOrg {
@@ -728,13 +747,30 @@ async fn cmd_report_cross_org(
 
 async fn cmd_pr_open(
     title: String,
-    body: String,
+    mut body: String,
     head: String,
     base: String,
     owner: String,
     repo: String,
     librarian: bool,
+    require_local_ci: bool,
 ) -> Result<()> {
+    let repo_root = aivcs_core::find_repo_root();
+
+    if require_local_ci {
+        aivcs_core::run_local_ci(&repo_root)?;
+    }
+
+    // Always generate snapshot and embed in body
+    let snapshot = aivcs_core::build_ci_snapshot(&repo_root)?;
+    let digest = snapshot.digest();
+    body = format!(
+        "{}\n\n<!-- aivcs-ci-snapshot: sha256:{} config-hash:{} -->",
+        body,
+        digest,
+        snapshot.local_ci_config_hash
+    );
+
     let client = github_client_from_env(owner, repo)?;
 
     let pr_number = client
@@ -800,6 +836,7 @@ struct PrPipelineArgs {
     repo: String,
     librarian: bool,
     skip_branch: bool,
+    require_local_ci: bool,
 }
 
 async fn cmd_pr_pipeline(args: PrPipelineArgs) -> Result<()> {
@@ -810,12 +847,29 @@ async fn cmd_pr_pipeline(args: PrPipelineArgs) -> Result<()> {
         file,
         message,
         title,
-        body,
+        mut body,
         owner,
         repo,
         librarian,
         skip_branch,
+        require_local_ci,
     } = args;
+
+    let repo_root = aivcs_core::find_repo_root();
+
+    if require_local_ci {
+        aivcs_core::run_local_ci(&repo_root)?;
+    }
+
+    // Always generate snapshot and embed in body
+    let snapshot = aivcs_core::build_ci_snapshot(&repo_root)?;
+    let digest = snapshot.digest();
+    body = format!(
+        "{}\n\n<!-- aivcs-ci-snapshot: sha256:{} config-hash:{} -->",
+        body,
+        digest,
+        snapshot.local_ci_config_hash
+    );
 
     let github_repo = format!("{owner}/{repo}");
     let client = github_client_from_env(owner.clone(), repo.clone())?;
@@ -847,6 +901,56 @@ async fn cmd_pr_pipeline(args: PrPipelineArgs) -> Result<()> {
     println!("Successfully opened PR #{pr_number}");
 
     Ok(())
+}
+
+async fn cmd_pr_verify_snapshot(pr_body: Option<String>) -> Result<()> {
+    let repo_root = aivcs_core::find_repo_root();
+
+    // 1. Get PR body
+    let body = if let Some(b) = pr_body {
+        b
+    } else if let Ok(event_path) = std::env::var("GITHUB_EVENT_PATH") {
+        let content = std::fs::read_to_string(event_path)
+            .context("Failed to read GITHUB_EVENT_PATH")?;
+        let event: serde_json::Value = serde_json::from_str(&content)
+            .context("Failed to parse GITHUB_EVENT_PATH JSON")?;
+
+        if let Some(body_val) = event.pointer("/pull_request/body") {
+            body_val.as_str().unwrap_or_default().to_string()
+        } else {
+            anyhow::bail!("Could not find pull_request.body in GITHUB_EVENT_PATH");
+        }
+    } else {
+        anyhow::bail!("No PR body provided and GITHUB_EVENT_PATH is not set");
+    };
+
+    // 2. Extract snapshot digest from PR body
+    // Look for: <!-- aivcs-ci-snapshot: sha256:<digest> config-hash:<hash> -->
+    let pattern = "<!-- aivcs-ci-snapshot: sha256:";
+    let idx = body.find(pattern).context("No aivcs-ci-snapshot digest found in PR body. Did you open this PR using 'aivcs pr pipeline'?")?;
+    let start = idx + pattern.len();
+    let rest = &body[start..];
+    let end_idx = rest.find(' ').or_else(|| rest.find("-->")).context("Malformed aivcs-ci-snapshot in PR body")?;
+    let expected_digest = rest[..end_idx].trim().to_string();
+
+    println!("Extracted snapshot digest from PR body: {}", expected_digest);
+
+    // 3. Recompute snapshot
+    let snapshot = aivcs_core::build_ci_snapshot(&repo_root)?;
+    let computed_digest = snapshot.digest();
+    println!("Computed snapshot digest from HEAD: {}", computed_digest);
+
+    if expected_digest == computed_digest {
+        println!("✓ Snapshot verification successful!");
+        Ok(())
+    } else {
+        println!("Expected snapshot details:");
+        println!("  repo_sha: {}", snapshot.repo_sha);
+        println!("  workspace_hash: {}", snapshot.workspace_hash);
+        println!("  local_ci_config_hash: {}", snapshot.local_ci_config_hash);
+        println!("  env_hash: {}", snapshot.env_hash);
+        anyhow::bail!("✗ Snapshot verification failed! The current HEAD state does not match the local-ci snapshot in the PR body. Did you push unstaged/untested changes without using aivcs pr pipeline?")
+    }
 }
 
 fn github_client_from_env(owner: String, repo: String) -> Result<aivcs_core::github::GitHubClient> {

--- a/crates/aivcs-core/src/ci_snapshot.rs
+++ b/crates/aivcs-core/src/ci_snapshot.rs
@@ -1,0 +1,138 @@
+//! CI snapshot generation and verification for AIVCS.
+
+use std::path::{Path, PathBuf};
+use sha2::{Digest, Sha256};
+use anyhow::{Result, Context};
+use oxidized_state::CiSnapshot;
+
+/// Compute deterministic hash of all files in the directory recursively.
+/// Skips common non-source directories (e.g. .git, target, node_modules, .local-ci-cache, .direnv).
+pub fn compute_workspace_hash(dir: &Path) -> Result<String> {
+    let mut files = Vec::new();
+    collect_files_recursive(dir, dir, &mut files)?;
+    files.sort_by(|a, b| a.0.cmp(&b.0)); // sort relative paths deterministically
+
+    let mut hasher = Sha256::new();
+    for (rel_path, abs_path) in files {
+        hasher.update(rel_path.as_bytes());
+        hasher.update(b"\0");
+        if let Ok(content) = std::fs::read(&abs_path) {
+            hasher.update(&content);
+        }
+        hasher.update(b"\0");
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn collect_files_recursive(
+    root: &Path,
+    dir: &Path,
+    files: &mut Vec<(String, PathBuf)>,
+) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = path.file_name().unwrap_or_default().to_string_lossy();
+        if name.starts_with('.') && name != ".local-ci.toml" {
+            // Skip hidden files/directories except .local-ci.toml
+            continue;
+        }
+        if name == "target" || name == "node_modules" || name == "dist" || name == ".git" || name == ".local-ci-cache" || name == ".direnv" {
+            continue;
+        }
+        if path.is_dir() {
+            collect_files_recursive(root, &path, files)?;
+        } else if path.is_file() {
+            if let Ok(rel) = path.strip_prefix(root) {
+                files.push((rel.to_string_lossy().to_string(), path));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Helper to get repo root using `git rev-parse --show-toplevel`.
+pub fn find_repo_root() -> PathBuf {
+    if let Ok(output) = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+    {
+        if output.status.success() {
+            let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            return PathBuf::from(path_str);
+        }
+    }
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
+/// Run local-ci check on the workspace
+pub fn run_local_ci(repo_root: &Path) -> Result<()> {
+    println!("Executing local-ci against workspace: {:?}", repo_root);
+    let status = std::process::Command::new("local-ci")
+        .current_dir(repo_root)
+        .status()
+        .context("Failed to execute 'local-ci' command. Make sure it is installed and on your PATH.")?;
+    
+    if status.success() {
+        Ok(())
+    } else {
+        anyhow::bail!("local-ci checks failed. Please run 'local-ci --fix' locally and resolve all issues before opening a PR.")
+    }
+}
+
+/// Build a CiSnapshot for the current workspace
+pub fn build_ci_snapshot(repo_root: &Path) -> Result<CiSnapshot> {
+    // 1. Get repo commit SHA
+    // Try GITHUB_SHA env var first (handy in GHA)
+    let repo_sha = if let Ok(sha) = std::env::var("GITHUB_SHA") {
+        sha
+    } else if let Ok(output) = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo_root)
+        .output()
+    {
+        if output.status.success() {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        } else {
+            "unknown".to_string()
+        }
+    } else {
+        "unknown".to_string()
+    };
+
+    // 2. Compute workspace hash
+    let workspace_hash = compute_workspace_hash(repo_root)?;
+
+    // 3. Compute local-ci config hash
+    let local_ci_config_hash = {
+        let config_path = repo_root.join(".local-ci.toml");
+        if config_path.exists() {
+            let content = std::fs::read(&config_path)?;
+            let mut hasher = Sha256::new();
+            hasher.update(&content);
+            hex::encode(hasher.finalize())
+        } else {
+            let hasher = Sha256::new();
+            hex::encode(hasher.finalize())
+        }
+    };
+
+    // 4. Compute env hash using nix-env-manager
+    let env_hash = match nix_env_manager::generate_environment_hash(repo_root) {
+        Ok(nix_hash) => nix_hash.hash,
+        Err(_) => {
+            // Fallback to hashing workspace or a default
+            "unknown_env".to_string()
+        }
+    };
+
+    Ok(CiSnapshot {
+        repo_sha,
+        workspace_hash,
+        local_ci_config_hash,
+        env_hash,
+    })
+}

--- a/crates/aivcs-core/src/lib.rs
+++ b/crates/aivcs-core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod self_healing;
 pub mod telemetry;
 pub mod tooling;
 pub mod trace_artifact;
+pub mod ci_snapshot;
 
 pub use domain::{
     validate_run_event, AgentSpec, AgentSpecFields, AivcsError, DeterministicEvalRunner,
@@ -52,6 +53,8 @@ pub use a2a::{
 pub use git::{capture_head_sha, detect_github_repository, is_git_repo, parse_github_remote};
 
 pub use memory::{DecisionRecorder, DecisionRecorderConfig};
+
+pub use ci_snapshot::{build_ci_snapshot, compute_workspace_hash, find_repo_root, run_local_ci};
 
 pub use oxidized_state::{
     BranchRecord, CommitId, CommitRecord, DecisionRecord, MemoryProvenanceRecord, MemoryRecord,


### PR DESCRIPTION
This PR adds the --require-local-ci flag (defaulting to true) to aivcs pr pipeline and aivcs pr open, running local-ci before mutations, generating a CiSnapshot, and embedding the snapshot digest footer in the PR body. It also implements verify-snapshot to validate the footer in GHA.