### PR TITLE
feat(cli): link GitHub commits to aivcs CommitId in CODE_COMMITTED events

### DIFF
--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -696,20 +696,23 @@ async fn main() -> Result<()> {
                 skip_branch,
                 require_local_ci,
             } => {
-                cmd_pr_pipeline(&handle, PrPipelineArgs {
-                    branch,
-                    base,
-                    path,
-                    file,
-                    message,
-                    title,
-                    body,
-                    owner,
-                    repo,
-                    librarian,
-                    skip_branch,
-                    require_local_ci,
-                })
+                cmd_pr_pipeline(
+                    &handle,
+                    PrPipelineArgs {
+                        branch,
+                        base,
+                        path,
+                        file,
+                        message,
+                        title,
+                        body,
+                        owner,
+                        repo,
+                        librarian,
+                        skip_branch,
+                        require_local_ci,
+                    },
+                )
                 .await
             }
             PrAction::VerifySnapshot { pr_body } => cmd_pr_verify_snapshot(pr_body).await,

--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -681,7 +681,7 @@ async fn main() -> Result<()> {
                 file,
                 owner,
                 repo,
-            } => cmd_pr_commit(branch, path, message, file, owner, repo).await,
+            } => cmd_pr_commit(&handle, branch, path, message, file, owner, repo).await,
             PrAction::Pipeline {
                 branch,
                 base,
@@ -696,7 +696,7 @@ async fn main() -> Result<()> {
                 skip_branch,
                 require_local_ci,
             } => {
-                cmd_pr_pipeline(PrPipelineArgs {
+                cmd_pr_pipeline(&handle, PrPipelineArgs {
                     branch,
                     base,
                     path,
@@ -814,6 +814,7 @@ async fn read_file_for_github_commit(file: &PathBuf) -> Result<Vec<u8>> {
 }
 
 async fn cmd_pr_commit(
+    handle: &SurrealHandle,
     branch: String,
     path: String,
     message: String,
@@ -830,13 +831,18 @@ async fn cmd_pr_commit(
         .await?;
     println!("Committed '{path}' to branch '{branch}' ({sha})");
 
+    let aivcs_commit_id = match handle.get_branch(&branch).await {
+        Ok(Some(b)) => Some(b.head_commit_id),
+        _ => None,
+    };
+
     aivcs_core::maybe_emit_code_committed_from_env(
         &branch,
         &sha,
         vec![path.clone()],
         "github-pr-commit",
         Some(&github_repo),
-        None,
+        aivcs_commit_id.as_deref(),
     )
     .await;
 
@@ -858,7 +864,7 @@ struct PrPipelineArgs {
     require_local_ci: bool,
 }
 
-async fn cmd_pr_pipeline(args: PrPipelineArgs) -> Result<()> {
+async fn cmd_pr_pipeline(handle: &SurrealHandle, args: PrPipelineArgs) -> Result<()> {
     let PrPipelineArgs {
         branch,
         base,
@@ -903,13 +909,18 @@ async fn cmd_pr_pipeline(args: PrPipelineArgs) -> Result<()> {
         .await?;
     println!("Committed '{path}' to branch '{branch}' ({sha})");
 
+    let aivcs_commit_id = match handle.get_branch(&branch).await {
+        Ok(Some(b)) => Some(b.head_commit_id),
+        _ => None,
+    };
+
     aivcs_core::maybe_emit_code_committed_from_env(
         &branch,
         &sha,
         vec![path.clone()],
         "github-pr-pipeline",
         Some(&github_repo),
-        None,
+        aivcs_commit_id.as_deref(),
     )
     .await;
 

--- a/crates/aivcs-core/src/ci_snapshot.rs
+++ b/crates/aivcs-core/src/ci_snapshot.rs
@@ -1,9 +1,9 @@
 //! CI snapshot generation and verification for AIVCS.
 
-use std::path::{Path, PathBuf};
-use sha2::{Digest, Sha256};
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use oxidized_state::CiSnapshot;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
 
 /// Compute deterministic hash of all files in the directory recursively.
 /// Skips common non-source directories (e.g. .git, target, node_modules, .local-ci-cache, .direnv).
@@ -40,7 +40,13 @@ fn collect_files_recursive(
             // Skip hidden files/directories except .local-ci.toml
             continue;
         }
-        if name == "target" || name == "node_modules" || name == "dist" || name == ".git" || name == ".local-ci-cache" || name == ".direnv" {
+        if name == "target"
+            || name == "node_modules"
+            || name == "dist"
+            || name == ".git"
+            || name == ".local-ci-cache"
+            || name == ".direnv"
+        {
             continue;
         }
         if path.is_dir() {
@@ -74,8 +80,10 @@ pub fn run_local_ci(repo_root: &Path) -> Result<()> {
     let status = std::process::Command::new("local-ci")
         .current_dir(repo_root)
         .status()
-        .context("Failed to execute 'local-ci' command. Make sure it is installed and on your PATH.")?;
-    
+        .context(
+            "Failed to execute 'local-ci' command. Make sure it is installed and on your PATH.",
+        )?;
+
     if status.success() {
         Ok(())
     } else {

--- a/crates/aivcs-core/src/lib.rs
+++ b/crates/aivcs-core/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod a2a;
 pub mod cas;
+pub mod ci_snapshot;
 pub mod compat;
 pub mod deploy;
 pub mod deploy_runner;
@@ -34,7 +35,6 @@ pub mod self_healing;
 pub mod telemetry;
 pub mod tooling;
 pub mod trace_artifact;
-pub mod ci_snapshot;
 
 pub use domain::{
     validate_run_event, AgentSpec, AgentSpecFields, AivcsError, DeterministicEvalRunner,


### PR DESCRIPTION
Passes the local branch's head commit ID from SurrealDB as the aivcs_commit_id to CODE_COMMITTED event payloads when running pr commit or pr pipeline.