### PR TITLE
fix(sdf): follow-up — address CRR findings F1+F2+F5+F7 on merged #223

### DIFF
--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -655,7 +655,19 @@ async fn main() -> Result<()> {
                 repo,
                 librarian,
                 require_local_ci,
-            } => cmd_pr_open(title, body, head, base, owner, repo, librarian, require_local_ci).await,
+            } => {
+                cmd_pr_open(
+                    title,
+                    body,
+                    head,
+                    base,
+                    owner,
+                    repo,
+                    librarian,
+                    require_local_ci,
+                )
+                .await
+            }
             PrAction::Branch {
                 name,
                 base,
@@ -774,9 +786,7 @@ async fn cmd_pr_open(
     let digest = snapshot.digest();
     body = format!(
         "{}\n\n<!-- aivcs-ci-snapshot: sha256:{} config-hash:{} -->",
-        body,
-        digest,
-        snapshot.local_ci_config_hash
+        body, digest, snapshot.local_ci_config_hash
     );
 
     let client = github_client_from_env(owner, repo)?;
@@ -875,9 +885,7 @@ async fn cmd_pr_pipeline(args: PrPipelineArgs) -> Result<()> {
     let digest = snapshot.digest();
     body = format!(
         "{}\n\n<!-- aivcs-ci-snapshot: sha256:{} config-hash:{} -->",
-        body,
-        digest,
-        snapshot.local_ci_config_hash
+        body, digest, snapshot.local_ci_config_hash
     );
 
     let github_repo = format!("{owner}/{repo}");
@@ -920,10 +928,10 @@ async fn cmd_pr_verify_snapshot(pr_body: Option<String>) -> Result<()> {
     let body = if let Some(b) = pr_body {
         b
     } else if let Ok(event_path) = std::env::var("GITHUB_EVENT_PATH") {
-        let content = std::fs::read_to_string(event_path)
-            .context("Failed to read GITHUB_EVENT_PATH")?;
-        let event: serde_json::Value = serde_json::from_str(&content)
-            .context("Failed to parse GITHUB_EVENT_PATH JSON")?;
+        let content =
+            std::fs::read_to_string(event_path).context("Failed to read GITHUB_EVENT_PATH")?;
+        let event: serde_json::Value =
+            serde_json::from_str(&content).context("Failed to parse GITHUB_EVENT_PATH JSON")?;
 
         if let Some(body_val) = event.pointer("/pull_request/body") {
             body_val.as_str().unwrap_or_default().to_string()
@@ -940,10 +948,16 @@ async fn cmd_pr_verify_snapshot(pr_body: Option<String>) -> Result<()> {
     let idx = body.find(pattern).context("No aivcs-ci-snapshot digest found in PR body. Did you open this PR using 'aivcs pr pipeline'?")?;
     let start = idx + pattern.len();
     let rest = &body[start..];
-    let end_idx = rest.find(' ').or_else(|| rest.find("-->")).context("Malformed aivcs-ci-snapshot in PR body")?;
+    let end_idx = rest
+        .find(' ')
+        .or_else(|| rest.find("-->"))
+        .context("Malformed aivcs-ci-snapshot in PR body")?;
     let expected_digest = rest[..end_idx].trim().to_string();
 
-    println!("Extracted snapshot digest from PR body: {}", expected_digest);
+    println!(
+        "Extracted snapshot digest from PR body: {}",
+        expected_digest
+    );
 
     // 3. Recompute snapshot
     let snapshot = aivcs_core::build_ci_snapshot(&repo_root)?;
@@ -1016,12 +1030,13 @@ async fn cmd_snapshot(
     let state: serde_json::Value =
         serde_json::from_str(&state_content).context("Failed to parse state as JSON")?;
 
-    // Resolve git SHA: use override, or auto-detect from cwd (optional)
+    // Resolve git SHA: use override, or auto-detect from cwd. Sentinel
+    // `None` means "no git context" — used by the local-print path and the
+    // A2A emit gate below. See the matching block on the emit site.
     let cwd = std::env::current_dir().context("Failed to get current directory")?;
-    let git_sha = match git_sha_override {
-        Some(sha) => sha.to_string(),
-        None => aivcs_core::capture_head_sha(&cwd)
-            .unwrap_or_else(|_| "0000000000000000000000000000000000000000".to_string()),
+    let git_sha: Option<String> = match git_sha_override {
+        Some(sha) => Some(sha.to_string()),
+        None => aivcs_core::capture_head_sha(&cwd).ok(),
     };
 
     // Generate logic and environment hashes for composite CommitId
@@ -1067,25 +1082,38 @@ async fn cmd_snapshot(
     let branch_record = BranchRecord::new(branch, &commit_id.hash, branch == "main");
     handle.save_branch(&branch_record).await?;
 
-    aivcs_core::maybe_emit_code_committed_from_env(
-        branch,
-        &git_sha,
-        vec![state_path.display().to_string()],
-        author,
-        None,
-        Some(&commit_id.hash),
-    )
-    .await;
+    // Same A2A gate as `cmd_merge`: only emit CODE_COMMITTED when we have
+    // a real git SHA. Emitting with a placeholder hash would be a lie to
+    // any consumer that joins on `commit_sha`.
+    if let Some(sha) = &git_sha {
+        aivcs_core::maybe_emit_code_committed_from_env(
+            branch,
+            sha,
+            vec![state_path.display().to_string()],
+            author,
+            None,
+            Some(&commit_id.hash),
+        )
+        .await;
+    } else {
+        tracing::warn!(
+            aivcs_commit_id = %commit_id.hash,
+            "skipping CODE_COMMITTED emission for snapshot: git SHA unavailable"
+        );
+    }
 
     info!(
         cas_digest = %cas_digest,
-        git_sha = %git_sha,
+        git_sha = ?git_sha,
         "snapshot stored in CAS"
     );
 
     println!("[{}] {} ({})", branch, message, commit_id.short());
     println!("Commit:    {}", commit_id);
-    println!("Git SHA:   {}", git_sha);
+    println!(
+        "Git SHA:   {}",
+        git_sha.as_deref().unwrap_or("(unavailable)")
+    );
     println!("CAS digest: {}", cas_digest);
 
     Ok(())
@@ -1302,19 +1330,34 @@ async fn cmd_merge(
     // Update target branch head
     let branch = BranchRecord::new(target, &result.merge_commit_id.hash, target == "main");
     handle.save_branch(&branch).await?;
-    let cwd = std::env::current_dir().context("Failed to get current directory")?;
-    let git_sha = aivcs_core::capture_head_sha(&cwd)
-        .unwrap_or_else(|_| "0000000000000000000000000000000000000000".to_string());
 
-    aivcs_core::maybe_emit_code_committed_from_env(
-        target,
-        &git_sha,
-        Vec::new(),
-        "agent-git",
-        None,
-        Some(&result.merge_commit_id.hash),
-    )
-    .await;
+    // CODE_COMMITTED carries a `commit_sha` (git) AND an optional
+    // `aivcs_commit_id` (this merge's aivcs hash). The git side has no
+    // meaningful value if git isn't available, and emitting a 40-char
+    // string of zeros is indistinguishable from a real SHA to downstream
+    // consumers — strictly worse than not emitting at all. Skip the A2A
+    // side-effect and log; the aivcs merge itself is already durable.
+    let cwd = std::env::current_dir().context("Failed to get current directory")?;
+    match aivcs_core::capture_head_sha(&cwd) {
+        Ok(git_sha) => {
+            aivcs_core::maybe_emit_code_committed_from_env(
+                target,
+                &git_sha,
+                Vec::new(),
+                "agent-git",
+                None,
+                Some(&result.merge_commit_id.hash),
+            )
+            .await;
+        }
+        Err(e) => {
+            tracing::warn!(
+                aivcs_commit_id = %result.merge_commit_id.hash,
+                error = %e,
+                "skipping CODE_COMMITTED emission for merge: git SHA unavailable"
+            );
+        }
+    }
 
     println!("Merge complete: {}", result.merge_commit_id.short());
     println!("{}", result.summary);
@@ -2093,7 +2136,8 @@ async fn cmd_pr_note(handle: &SurrealHandle, branch_name_opt: Option<&str>) -> R
     if let Some(intent_id) = read_objective_id() {
         println!("intent-id: {}", intent_id);
     }
-    println!("\n### AIVCS Commit Summary");
+    println!();
+    println!("### AIVCS Commit Summary");
     println!("- **Message**: {}", commit.message);
     println!("- **Author**: {}", commit.author);
     println!("- **Created**: {}", commit.created_at);
@@ -2157,10 +2201,15 @@ mod tests {
     #[tokio::test]
     async fn test_pr_note_command() {
         let handle = SurrealHandle::setup_db().await.unwrap();
-        cmd_init(&handle, &PathBuf::from(".")).await.unwrap();
-
-        // Create a snapshot to produce a commit and update the branch
+        // Use a temp dir for cmd_init so the test is hermetic. Previously
+        // this called `cmd_init(&handle, &PathBuf::from("."))`, which leaked
+        // init artifacts into whatever cwd `cargo test` ran from.
         let temp_dir = tempfile::tempdir().unwrap();
+        cmd_init(&handle, &temp_dir.path().to_path_buf())
+            .await
+            .unwrap();
+
+        // Create a snapshot to produce a commit and update the branch.
         let state_path = temp_dir.path().join("state.json");
         std::fs::write(&state_path, r#"{"step": 1, "value": "test"}"#).unwrap();
 
@@ -2171,7 +2220,7 @@ mod tests {
             "test-author",
             "main",
             Some("1234567890abcdef1234567890abcdef12345678"),
-            None,
+            Some(&temp_dir.path().join("cas")),
         )
         .await
         .unwrap();

--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -1104,7 +1104,7 @@ async fn cmd_snapshot(
 
     info!(
         cas_digest = %cas_digest,
-        git_sha = ?git_sha,
+        git_sha = %git_sha.as_deref().unwrap_or("(unavailable)"),
         "snapshot stored in CAS"
     );
 

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,16 @@
             strictDeps = true;
             buildInputs = with pkgs; [
               openssl
+            ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              # Required on macOS for the OpenSSL / reqwest / git2 chain that
+              # aivcs-core depends on. Removed in #223 without an explanation;
+              # restoring because the CI matrix is Linux-only, so removing
+              # silently broke `nix develop` and `nix build` for any macOS
+              # contributor. If a future refactor genuinely removes the
+              # dependency on these frameworks, drop these AND add a darwin
+              # builder to CI to prove the removal is safe.
+              pkgs.darwin.apple_sdk.frameworks.Security
+              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
             ];
             nativeBuildInputs = with pkgs; [
               pkg-config


### PR DESCRIPTION
Follow-up to merged [#223](https://github.com/stevedores-org/aivcs/pull/223). Addresses [F1, F2, F5, F7 from the CRR](https://github.com/stevedores-org/aivcs/pull/223#pullrequestreview-4482087845) on that PR. The original was merged before an \`acr\` commit could land on it, so the fixes apply on \`develop\` instead.

## What changed

| Finding | Severity | Fix |
|---|---|---|
| **F1** \`cmd_merge\` / \`cmd_snapshot\` emitted \`CODE_COMMITTED\` with all-zero placeholder when \`capture_head_sha\` failed | MED | Both call sites now gate the A2A emission on a real SHA and \`tracing::warn!\` when skipped. \`cmd_snapshot\` also surfaces \"(unavailable)\" in its local-print output. |
| **F2** \`flake.nix\` removed Darwin Security / SystemConfiguration frameworks; CI is Linux-only so the change was unverified for macOS | MED | Restored the conditional with an inline comment explaining the dependency and what removing it again would require (CI matrix addition). |
| **F5** \`test_pr_note_command\` called \`cmd_init(&handle, &PathBuf::from(\".\"))\` leaking artifacts into cwd | LOW | Switched the test to the already-in-scope \`temp_dir\` and routed \`cas_dir\` through it so the test is fully hermetic. |
| **F7** \`println!(\"\\n### AIVCS Commit Summary\")\` produced two newlines via \`\\n\` + \`println!\`'s own | LOW | Split into \`println!()\` + the heading on its own line. Cosmetic; output now matches the obvious read. |

## Verification

- \`cargo build -p aivcs-cli\` — clean
- \`cargo test -p aivcs-cli\` — **9/9 pass**, including:
  - \`test_pr_note_command\` (covers F5 hermetic path + F7 output)
  - \`test_agent_git_snapshot_cli_returns_valid_id\` (cmd_snapshot refactor for F1)
  - \`test_snapshot_auto_detects_git_sha_in_repo\` (happy path of the new \`Option<String>\` git_sha shape)
- \`cargo fmt -p aivcs-cli --check\` — clean

## Not in scope

| Finding | Why deferred |
|---|---|
| **F3** scope creep on #223 (templates) | Judgment call about how to split PRs; the templates are already merged so nothing to act on now. |
| **F4** manual YAML parse in \`read_objective_id\` | Would add a \`serde_yaml\` dep + a 5-line struct; worth doing but not urgent for the pilot inputs. |
| **F6** intent-block drift CI check | Would add a workflow step; worth doing as part of a SIX-FILES-COMPILER cleanup, not this fix. |
| **F8** README \`aivcs pr-note\` example | Worth adding; deferred to a docs-only PR. |

All four open findings still tracked on the closed CRR thread for whoever picks them up.

Refs [CRR pullrequestreview-4482087845](https://github.com/stevedores-org/aivcs/pull/223#pullrequestreview-4482087845).