### PR TITLE
fix(git): tighten GitHub remote charset + detached-HEAD error test (refs #231 M3/M4)

### DIFF
--- a/crates/aivcs-core/src/git.rs
+++ b/crates/aivcs-core/src/git.rs
@@ -260,6 +260,16 @@ mod tests {
         // Empty segments still rejected (regression guard).
         assert_eq!(parse_github_remote("git@github.com:/repo"), None);
         assert_eq!(parse_github_remote("git@github.com:owner/"), None);
+        // HTTPS-side coverage — the same gate must reject these too.
+        // (Develop already covers the SSH-side cases above; #237 added
+        // these HTTPS-shape variants which weren't in the original
+        // M4 sweep.)
+        assert_eq!(parse_github_remote("https://github.com/foo bar/baz"), None);
+        assert_eq!(parse_github_remote("https://github.com//repo"), None);
+        assert_eq!(parse_github_remote("https://github.com/owner/"), None);
+        // Backticks (command-substitution metachar) on the SSH side —
+        // distinct from the `;` shell-separator case already covered.
+        assert_eq!(parse_github_remote("git@github.com:`whoami`/repo"), None);
     }
 
     #[test]


### PR DESCRIPTION
Closes the M3 and M4 follow-ups from #231.

## Summary
- **M4**: `parse_github_remote` now validates the GitHub user/repo charset (`[A-Za-z0-9._-]+`). The old `is_owner_repo` only rejected empty segments and a third slash, so a remote like `git@github.com:malicious\n/payload` would parse and flow into downstream `format!("{owner}/{repo}")` paths.
- **M3**: `detect_current_branch_detached_head_returns_err` now asserts the corrective-action suffix (`pass --branch explicitly`), not just the state name. The suffix is what the user sees and was previously unprotected against a silent removal.

## Out of scope (left on #231 for separate PRs)
- H1, H4: retro comments on PR #223 (need a human voice / write-up).
- H2, H3, L1, L2: `.cursorrules` changes — cross-tool behavioral effects deserve a dedicated PR.
- M1, M2, M5: design decisions, not mechanical fixes.
- L3: `println!()` separator before the markdown heading is intentional (blank line between metadata and heading).
- L4: bare `ssh://git@.../owner/repo` (no `.git`) is already covered by `parse_github_remote_supports_rfc_ssh_url` at line 209.

## Test plan
- [x] `cargo test -p aivcs-core --lib git::` — 10/10 pass locally (incl. new `parse_github_remote_rejects_invalid_characters`).
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy -p aivcs-core --tests -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)