### PR TITLE
feat(ci): split nix-checks into parallel matrix shards (Phase 1 of #240)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,27 @@ jobs:
       - name: Doc Tests
         run: cargo test --doc --workspace --profile ci
 
+  # Each shard builds one flake derivation in parallel so a 30s `fmt`
+  # regression fails fast instead of waiting behind a 6-minute `tests`
+  # build. Wall-clock = slowest shard, not sum of all derivations.
+  # See stevedores-org/aivcs#240 (TDD).
   nix-checks:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - check: clippy
+            path: checks
+          - check: fmt
+            path: checks
+          - check: tests
+            path: checks
+          - check: aivcs
+            path: packages
+          - check: aivcsd
+            path: packages
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,5 +87,22 @@ jobs:
             extra-substituters = https://nix-cache.stevedores.org
             extra-trusted-public-keys = stevedores-cache-1:bXLxkipycRWproIJnk8pPWNFdgVfeV+I2mJXCoW4/ag=
 
-      - name: Nix flake check
-        run: nix flake check --print-build-logs
+      - name: Build ${{ matrix.path }}.${{ matrix.check }}
+        run: nix build ".#${{ matrix.path }}.x86_64-linux.${{ matrix.check }}" --print-build-logs
+
+  # Single required-check at branch protection. Matrix legs above are
+  # informational; this aggregator fails iff any leg failed. Without it,
+  # branch protection would need to track 5 individual matrix-leg names
+  # that re-name themselves when the matrix shape changes.
+  nix-checks-summary:
+    runs-on: ubuntu-latest
+    needs: [nix-checks]
+    if: always()
+    steps:
+      - name: Summarise nix-checks matrix
+        run: |
+          if [ "${{ needs.nix-checks.result }}" != "success" ]; then
+            echo "::error::one or more nix-checks shards failed (result: ${{ needs.nix-checks.result }})"
+            exit 1
+          fi
+          echo "all nix-checks shards passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,11 @@ jobs:
           - check: aivcsd
             path: packages
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # `tests` is the long pole — it compiles the whole workspace AND runs
+    # nextest on a cold ubuntu-latest runner. Observed 20m+ on the first
+    # Phase 1 run (PR #244, job 81204220659), so 30m for ample headroom.
+    # Other shards finish in 1–20m and exit well under the cap.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Closes Phase 1 of #240.

## What changed

Replaces the monolithic `nix flake check` step (one step, all derivations serial, 21 minutes wall-clock) with a 5-leg matrix that builds each flake derivation in parallel:

| Shard | Command |
|---|---|
| `checks.clippy` | `nix build .#checks.x86_64-linux.clippy` |
| `checks.fmt` | `nix build .#checks.x86_64-linux.fmt` |
| `checks.tests` | `nix build .#checks.x86_64-linux.tests` |
| `packages.aivcs` | `nix build .#packages.x86_64-linux.aivcs` |
| `packages.aivcsd` | `nix build .#packages.x86_64-linux.aivcsd` |

And adds a `nix-checks-summary` aggregator that fails iff any matrix leg failed.

## Why summary aggregator

Matrix legs in GitHub Actions surface as individual checks (`nix-checks (clippy)`, `nix-checks (fmt)`, etc.). If branch protection tracked each one, every matrix-shape change (adding a shard, renaming a derivation) would require updating branch protection. The aggregator decouples that: branch protection tracks one check (`nix-checks-summary`), matrix legs stay informational.

## Expected impact

Per the TDD's measurement plan:

| Scenario | Before | After (target) |
|---|---|---|
| Cold cache | ~21 min | ~8 min (bottleneck = slowest shard, likely `tests` at 7-9 min) |
| Warm cache | ~21 min | ~3-5 min (Cachix hit + per-leg setup ~30-60s) |
| `fmt` regression detection | ~21 min | ~1.5 min |

Will measure on 5 consecutive PR runs after merge.

## What did NOT change

- `nix flake check` semantics — local devs run the same command and exercise the same derivations. No change to `flake.nix`.
- `rust-checks` job — already cargo-native and fast (~2 min). Left alone.
- `nixos-wsl-build` (in `.github/workflows/nixos-wsl.yml`) — already a separate job in a separate workflow with its own path filter. The summary aggregator does not depend on it; it stays a separate required check at branch protection level. The TDD considered folding it in but it's not the long pole today.

## Required follow-up (operator action, post-merge)

**Branch protection** needs swapping: drop `nix-checks` from required checks, add `nix-checks-summary`. Open PRs will need a re-push to pick up the new required check name.

## Deferred to later PRs

- **Phase 2** (#240): split `tests` shard into 4 `cargo-nextest --partition count:K/4` shards if Phase 1 doesn't hit the 5-min warm-cache target.
- **Phase 3** (#240): `paths-ignore: ['**/*.md', 'docs/**']` on the workflow's `pull_request:` trigger.

## Risk

- **Cachix contention.** 5 shards hitting `nix-cache.stevedores.org` simultaneously. Worst case = first cold PR has a higher penalty; steady-state should be unaffected. If we see rate-limiting, drop concurrency or cap matrix legs at 3.
- **Per-leg Nix setup overhead.** Each shard re-installs Nix (~10-20s) and re-fetches the dep graph (~30-60s cold). Net positive when total wall-clock drops by 10+ min; if not, revisit.
- **In-flight PRs.** They'll see `nix-checks (clippy)` etc. as new checks alongside the old `nix-checks` until they rebase / re-push. Cosmetic, not blocking.

Ref: TDD #240