### PR TITLE
ci: crates.io publish workflow + release runbook

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Test
         run: cargo nextest run --workspace --cargo-profile ci --profile ci
 
+      - name: Doc Tests
+        run: cargo test --doc --workspace --profile ci
+
   publish-crates-io:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,89 @@
+name: publish
+
+# Publish AIVCS library crates to crates.io on version tags.
+# Binary GitHub Releases remain in release.yml — this workflow is for library crates only.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Package and validate only (no upload to crates.io)"
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: publish-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: short
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: publish
+          cache-targets: true
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Test
+        run: cargo nextest run --workspace --cargo-profile ci --profile ci
+
+  publish-crates-io:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: github.event_name == 'push' || github.event.inputs.dry_run == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish workspace crates (dependency order)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: ./scripts/publish-crates.sh
+
+  dry-run:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Package workspace crates (dry run)
+        run: ./scripts/publish-crates.sh --dry-run

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ The `pr commit` and `pr pipeline` commands support both text and binary files. C
 - [Local Development](docs/runbooks/local-development.md) — build, test, dev workflows
 - [Database Configuration](docs/runbooks/database-configuration.md) — in-memory, local, cloud setup
 - [CI Troubleshooting](docs/runbooks/ci-troubleshooting.md) — common failures, reproduce locally
+- [crates.io Release](docs/CRATES_IO_RELEASE.md) — publish library crates (tag → `publish.yml`)
 - [Zero-Touch PR Pipeline](docs/runbooks/zero-touch-pr-pipeline.md) — autonomous agent Jobs: branch, commit, PR, A2A
 
 ## Contributing

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -23,6 +23,11 @@ The workspace version in `Cargo.toml` is the single source of truth. All crates 
 
 - [ ] Merge `develop` into `main` via pull request
 - [ ] Tag the merge commit: `git tag v<VERSION> && git push origin v<VERSION>`
+- [ ] Verify the `publish.yml` workflow completes (library crates → crates.io):
+  - Test job green (fmt, clippy, nextest, doc tests)
+  - `publish-crates-io` publishes five crates in dependency order
+  - All versions visible on crates.io (`oxidized-state`, `nix-env-manager`, `semantic-rag-merge`, `aivcs-core`, `aivcs-ci`)
+  - Full runbook: [docs/CRATES_IO_RELEASE.md](docs/CRATES_IO_RELEASE.md)
 - [ ] Verify the `release.yml` GitHub Actions workflow completes:
   - Linux binary built
   - macOS binary built

--- a/docs/CRATES_IO_RELEASE.md
+++ b/docs/CRATES_IO_RELEASE.md
@@ -72,6 +72,18 @@ export CARGO_REGISTRY_TOKEN=$(security find-generic-password -s "CARGO_REGISTRY_
 
 Actions → **publish** → **Run workflow** → leave **dry_run** checked.
 
+## Partial publish recovery
+
+If `cargo publish` fails mid-loop (e.g. `aivcs-core` succeeds but `aivcs-ci` fails), already-published crate versions remain on crates.io and cannot be re-uploaded for the same semver.
+
+1. Fix the underlying issue (tests, metadata, token, network).
+2. Publish remaining crates manually:
+   ```bash
+   export CARGO_REGISTRY_TOKEN=$(security find-generic-password -s "CARGO_REGISTRY_TOKEN" -w)
+   cargo publish -p aivcs-ci   # example: only what failed
+   ```
+3. If the workspace version was corrupted or needs a fix, bump to the next **patch** version, update `CHANGELOG.md`, and tag again (`v0.3.3`).
+
 ## Publish order
 
 Enforced by [`scripts/publish-crates.sh`](../scripts/publish-crates.sh):

--- a/docs/CRATES_IO_RELEASE.md
+++ b/docs/CRATES_IO_RELEASE.md
@@ -1,0 +1,92 @@
+# crates.io release runbook (AIVCS)
+
+How to publish AIVCS **library crates** to [crates.io](https://crates.io). Owner: **`community-stevedores-org`**.
+
+Binary CLI releases (GitHub Releases) stay in [`.github/workflows/release.yml`](../.github/workflows/release.yml). Crate publishing is [`.github/workflows/publish.yml`](../.github/workflows/publish.yml).
+
+## Published crates
+
+| Crate | Role | Notes |
+|-------|------|-------|
+| `oxidized-state` | Layer 0 — SurrealDB persistence | leaf |
+| `nix-env-manager` | Layer 2 — Nix/Attic | leaf |
+| `semantic-rag-merge` | Layer 3 — semantic merge | depends on `oxidized-state` |
+| `aivcs-core` | Domain orchestration | depends on layers + `oxidizedgraph` |
+| `aivcs-ci` | CI pipeline / gates | depends on `aivcs-core` |
+
+**Not published:** `aivcs-cli`, `aivcsd` (`publish = false` in their `Cargo.toml`).
+
+**External dependency:** `aivcs-core` pins `oxidizedgraph = "0.2.0"` from crates.io — publish or verify `oxidizedgraph` before bumping AIVCS if that bound changes.
+
+## Registry strategy
+
+| Target | When to use |
+|--------|-------------|
+| **crates.io** (default) | Public library crates consumed outside the monorepo |
+| **`crates.stevedores.org`** | Private/pre-release (see [oxidizedgraph publish workflow](https://github.com/stevedores-org/oxidizedgraph/blob/main/.github/workflows/publish.yml)) |
+| **Path deps** | `lornu-ai/brains`, in-flight cross-repo work — no publish required |
+
+## Prerequisites
+
+### Local token (macOS Keychain)
+
+```bash
+export CARGO_REGISTRY_TOKEN=$(security find-generic-password -s "CARGO_REGISTRY_TOKEN" -w)
+```
+
+Store once:
+
+```bash
+security add-generic-password -a "$USER" -s "CARGO_REGISTRY_TOKEN" -w "<crates.io API token>"
+```
+
+### GitHub Actions secret
+
+Repo **`stevedores-org/aivcs`** → Settings → Secrets → `CARGO_REGISTRY_TOKEN` (same crates.io API token, scoped to publish).
+
+## Release checklist
+
+1. **Merge** changes to `main` (CI green).
+2. **Bump** `[workspace.package] version` in root `Cargo.toml` and matching `[workspace.dependencies]` version pins for internal crates.
+3. **Update** `CHANGELOG.md` under `[Unreleased]` → new version section.
+4. **Dry-run locally:**
+   ```bash
+   ./scripts/publish-crates.sh --dry-run
+   ```
+5. **Tag** (semver, with `v` prefix):
+   ```bash
+   git tag -a v0.3.2 -m "Release v0.3.2"
+   git push origin v0.3.2
+   ```
+6. **Verify** [publish workflow](https://github.com/stevedores-org/aivcs/actions/workflows/publish.yml) — test job → `publish-crates-io`.
+7. **Confirm** on crates.io: `oxidized-state`, `nix-env-manager`, `semantic-rag-merge`, `aivcs-core`, `aivcs-ci` all show the new version.
+
+### Manual publish (fallback)
+
+```bash
+export CARGO_REGISTRY_TOKEN=$(security find-generic-password -s "CARGO_REGISTRY_TOKEN" -w)
+./scripts/publish-crates.sh
+```
+
+### CI dry-run (no upload)
+
+Actions → **publish** → **Run workflow** → leave **dry_run** checked.
+
+## Publish order
+
+Enforced by [`scripts/publish-crates.sh`](../scripts/publish-crates.sh):
+
+```text
+oxidized-state → nix-env-manager → semantic-rag-merge → aivcs-core → aivcs-ci
+```
+
+`cargo publish` rewrites path dependencies to semver requirements from `Cargo.toml`.
+
+## Related repos
+
+| Repo | Publish workflow |
+|------|------------------|
+| [stevedores-org/aivcs](https://github.com/stevedores-org/aivcs) | `publish.yml` (this doc) |
+| [stevedores-org/oxidizedgraph](https://github.com/stevedores-org/oxidizedgraph) | `publish.yml` (single crate + optional `crates.stevedores.org`) |
+
+Agent skill: [lornu.ai-agent-skills `crates-io`](https://github.com/lornu-ai/lornu.ai-agent-skills/tree/main/skills/crates-io).

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Publish AIVCS library crates to crates.io in dependency order.
+# aivcs-cli and aivcsd are publish = false and are skipped.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+fi
+
+# Leaves first, then dependents. Matches workspace [workspace.dependencies].
+CRATES=(
+  oxidized-state
+  nix-env-manager
+  semantic-rag-merge
+  aivcs-core
+  aivcs-ci
+)
+
+if [[ "$DRY_RUN" == false && -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+  echo "error: CARGO_REGISTRY_TOKEN is not set" >&2
+  echo "helper: export CARGO_REGISTRY_TOKEN=\$(security find-generic-password -s \"CARGO_REGISTRY_TOKEN\" -w)" >&2
+  exit 1
+fi
+
+WORKSPACE_VERSION="$(grep '^version = ' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
+echo "workspace version: ${WORKSPACE_VERSION}"
+
+for crate in "${CRATES[@]}"; do
+  echo "==> ${crate}"
+  if [[ "$DRY_RUN" == true ]]; then
+    cargo publish -p "$crate" --dry-run
+  else
+    cargo publish -p "$crate"
+  fi
+done
+
+echo "done: ${#CRATES[@]} crate(s)"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/publish.yml` — on tag `v*`: test → publish five library crates to crates.io in dependency order
- Add `scripts/publish-crates.sh` with `--dry-run` and Keychain token helper
- Add `docs/CRATES_IO_RELEASE.md` runbook; link from README

Companion: https://github.com/lornu-ai/lornu.ai-agent-skills (feat/crates-io-skill)

## Ops prerequisite
Set repo secret `CARGO_REGISTRY_TOKEN` before first tag publish.

## Test plan
- [x] `bash -n scripts/publish-crates.sh`
- [ ] Merge → workflow_dispatch with `dry_run=true`
- [ ] Tag `v0.3.2` when ready for live publish


Made with [Cursor](https://cursor.com)