### PR TITLE
chore: release v0.3.2 for crates.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-15
+
+### Added
+- crates.io publish workflow (`publish.yml`) and release runbook
+
 ## [0.1.0] - 2026-02-18
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["Stevedores Org <engineering@stevedores.org>"]
 license = "Apache-2.0"
@@ -71,11 +71,11 @@ tempfile = "3.10"
 oxidizedgraph = "0.2.0"
 
 # Internal crates (use published versions for crates.io)
-aivcs-core = { version = "0.3.1", path = "crates/aivcs-core" }
-aivcs-ci = { version = "0.3.1", path = "crates/aivcs-ci" }
-oxidized-state = { version = "0.3.1", path = "crates/oxidized-state" }
-nix-env-manager = { version = "0.3.1", path = "crates/nix-env-manager" }
-semantic-rag-merge = { version = "0.3.1", path = "crates/semantic-rag-merge" }
+aivcs-core = { version = "0.3.2", path = "crates/aivcs-core" }
+aivcs-ci = { version = "0.3.2", path = "crates/aivcs-ci" }
+oxidized-state = { version = "0.3.2", path = "crates/oxidized-state" }
+nix-env-manager = { version = "0.3.2", path = "crates/nix-env-manager" }
+semantic-rag-merge = { version = "0.3.2", path = "crates/semantic-rag-merge" }
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
## Summary
- Bump workspace to **0.3.2**
- Changelog entry for publish workflow release

## After merge
1. Set `CARGO_REGISTRY_TOKEN` on repo (crates.io API token for `community-stevedores-org`)
2. Tag: `git tag v0.3.2 && git push origin v0.3.2` → triggers `publish.yml`
3. Or local: `./scripts/publish-crates.sh`


Made with [Cursor](https://cursor.com)