### PR TITLE
feat(cli): aivcs pr-semantic-summary — graph-diff Markdown for PR bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "aivcs-auth"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aivcs-core",
  "anyhow",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aivcs-ci"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aivcs-core",
  "anyhow",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aivcs-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aivcs-ci",
  "aivcs-core",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "aivcs-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "aivcs-mcp-gateway"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aivcs-core",
  "anyhow",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "aivcsd"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aivcs-core",
  "anyhow",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "nix-env-manager"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2948,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "oxidized-state"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "semantic-rag-merge"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -2356,10 +2356,7 @@ async fn cmd_pr_note(handle: &SurrealHandle, branch_name_opt: Option<&str>) -> R
     Ok(())
 }
 
-async fn resolve_branch_commit(
-    handle: &SurrealHandle,
-    branch_name: &str,
-) -> Result<CommitRecord> {
+async fn resolve_branch_commit(handle: &SurrealHandle, branch_name: &str) -> Result<CommitRecord> {
     let branch = handle
         .get_branch(branch_name)
         .await?
@@ -2381,9 +2378,7 @@ async fn cmd_pr_semantic_summary(
     branch_name_opt: Option<&str>,
     base_name: &str,
 ) -> Result<()> {
-    use aivcs_core::{
-        diff_graph_snapshots, extract_graph_snapshot, format_semantic_diff_markdown,
-    };
+    use aivcs_core::{diff_graph_snapshots, extract_graph_snapshot, format_semantic_diff_markdown};
 
     let branch_name = match branch_name_opt {
         Some(name) => name.to_string(),
@@ -2578,11 +2573,7 @@ mod tests {
         .unwrap();
 
         let res = cmd_pr_semantic_summary(&handle, Some("feat"), "main").await;
-        assert!(
-            res.is_ok(),
-            "pr-semantic-summary failed: {:?}",
-            res.err()
-        );
+        assert!(res.is_ok(), "pr-semantic-summary failed: {:?}", res.err());
     }
 
     #[tokio::test]

--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -242,6 +242,20 @@ enum Commands {
         #[arg(short, long)]
         branch: Option<String>,
     },
+
+    /// Emit a semantic graph/prompt diff for PR bodies (SDF dual-ledger Phase 2.1).
+    ///
+    /// Resolves aivcs commits at HEAD (feature branch) and `--base`, diffs oxidizedgraph
+    /// snapshots embedded in commit state, and prints Markdown for the PR description.
+    PrSemanticSummary {
+        /// Feature branch (defaults to current git branch if omitted)
+        #[arg(short, long)]
+        branch: Option<String>,
+
+        /// Base branch to compare against
+        #[arg(long, default_value = "main")]
+        base: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -757,6 +771,9 @@ async fn main() -> Result<()> {
             } => cmd_report_cross_org(graph, &objective, output).await,
         },
         Commands::PrNote { branch } => cmd_pr_note(&handle, branch.as_deref()).await,
+        Commands::PrSemanticSummary { branch, base } => {
+            cmd_pr_semantic_summary(&handle, branch.as_deref(), &base).await
+        }
     }
 }
 
@@ -2303,20 +2320,7 @@ async fn cmd_pr_note(handle: &SurrealHandle, branch_name_opt: Option<&str>) -> R
         }
     };
 
-    let branch = handle
-        .get_branch(&branch_name)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("Branch '{}' not found in AIVCS database", branch_name))?;
-
-    let commit = handle
-        .get_commit(&branch.head_commit_id)
-        .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Commit '{}' not found in AIVCS database",
-                branch.head_commit_id
-            )
-        })?;
+    let commit = resolve_branch_commit(handle, &branch_name).await?;
 
     // Format output matching acceptance criteria.
     //
@@ -2348,6 +2352,76 @@ async fn cmd_pr_note(handle: &SurrealHandle, branch_name_opt: Option<&str>) -> R
     if let Some(env) = &commit.commit_id.env_hash {
         println!("- **Env Hash**: {}", env);
     }
+
+    Ok(())
+}
+
+async fn resolve_branch_commit(
+    handle: &SurrealHandle,
+    branch_name: &str,
+) -> Result<CommitRecord> {
+    let branch = handle
+        .get_branch(branch_name)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Branch '{}' not found in AIVCS database", branch_name))?;
+
+    handle
+        .get_commit(&branch.head_commit_id)
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Commit '{}' not found in AIVCS database",
+                branch.head_commit_id
+            )
+        })
+}
+
+async fn cmd_pr_semantic_summary(
+    handle: &SurrealHandle,
+    branch_name_opt: Option<&str>,
+    base_name: &str,
+) -> Result<()> {
+    use aivcs_core::{
+        diff_graph_snapshots, extract_graph_snapshot, format_semantic_diff_markdown,
+    };
+
+    let branch_name = match branch_name_opt {
+        Some(name) => name.to_string(),
+        None => {
+            let cwd = std::env::current_dir().context("Failed to get current directory")?;
+            aivcs_core::detect_current_branch(&cwd)
+                .context("Failed to auto-detect current git branch")?
+        }
+    };
+
+    let _head_commit = resolve_branch_commit(handle, &branch_name).await?;
+    let _base_commit = resolve_branch_commit(handle, base_name).await?;
+
+    cmd_pr_note(handle, Some(&branch_name)).await?;
+
+    let head_snapshot = handle
+        .load_snapshot(&_head_commit.commit_id.hash)
+        .await
+        .context("Failed to load head branch snapshot")?;
+    let base_snapshot = handle
+        .load_snapshot(&_base_commit.commit_id.hash)
+        .await
+        .context("Failed to load base branch snapshot")?;
+
+    let head_graph = extract_graph_snapshot(&head_snapshot.state);
+    let base_graph = extract_graph_snapshot(&base_snapshot.state);
+
+    println!();
+    println!("### Semantic diff (`{base_name}` → `{branch_name}`)");
+    println!();
+
+    if !head_graph.has_semantic_content() && !base_graph.has_semantic_content() {
+        println!("_No semantic delta — only code/infra changes._");
+        return Ok(());
+    }
+
+    let diff = diff_graph_snapshots(&base_graph, &head_graph);
+    println!("{}", format_semantic_diff_markdown(&diff));
 
     Ok(())
 }
@@ -2432,6 +2506,83 @@ mod tests {
         // Run the pr-note command
         let res = cmd_pr_note(&handle, Some("main")).await;
         assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_pr_semantic_summary_command() {
+        let handle = SurrealHandle::setup_db().await.unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        cmd_init(&handle, &temp_dir.path().to_path_buf())
+            .await
+            .unwrap();
+
+        let base_state = temp_dir.path().join("base.json");
+        std::fs::write(
+            &base_state,
+            r#"{
+                "graph": {
+                    "entry": "start",
+                    "exits": ["end"],
+                    "nodes": ["start", "plan"],
+                    "edges": [{"from": "start", "to": "plan"}]
+                },
+                "prompts": {"plan": "Plan v1"}
+            }"#,
+        )
+        .unwrap();
+        cmd_snapshot(
+            &handle,
+            &base_state,
+            "base graph",
+            "agent",
+            "main",
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            Some(temp_dir.path().join("cas").as_path()),
+        )
+        .await
+        .unwrap();
+
+        let main_head = handle.get_branch_head("main").await.unwrap();
+        handle
+            .save_branch(&BranchRecord::new("feat", &main_head, false))
+            .await
+            .unwrap();
+
+        let head_state = temp_dir.path().join("head.json");
+        std::fs::write(
+            &head_state,
+            r#"{
+                "graph": {
+                    "entry": "start",
+                    "exits": ["end"],
+                    "nodes": ["start", "plan", "review"],
+                    "edges": [
+                        {"from": "start", "to": "plan"},
+                        {"from": "plan", "to": "review"}
+                    ]
+                },
+                "prompts": {"plan": "Plan v2", "review": "Review output"}
+            }"#,
+        )
+        .unwrap();
+        cmd_snapshot(
+            &handle,
+            &head_state,
+            "feature graph",
+            "agent",
+            "feat",
+            Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+            Some(temp_dir.path().join("cas").as_path()),
+        )
+        .await
+        .unwrap();
+
+        let res = cmd_pr_semantic_summary(&handle, Some("feat"), "main").await;
+        assert!(
+            res.is_ok(),
+            "pr-semantic-summary failed: {:?}",
+            res.err()
+        );
     }
 
     #[tokio::test]

--- a/crates/aivcs-core/src/diff/mod.rs
+++ b/crates/aivcs-core/src/diff/mod.rs
@@ -1,4 +1,5 @@
 pub mod lcs_diff;
 pub mod node_paths;
+pub mod semantic_graph;
 pub mod state_diff;
 pub mod tool_calls;

--- a/crates/aivcs-core/src/diff/semantic_graph.rs
+++ b/crates/aivcs-core/src/diff/semantic_graph.rs
@@ -116,8 +116,14 @@ pub fn extract_graph_snapshot(state: &Value) -> GraphSnapshot {
 
 fn parse_edge(edge: &Value) -> Option<(String, String)> {
     if let Some(obj) = edge.as_object() {
-        let from = obj.get("from").or_else(|| obj.get("source")).and_then(Value::as_str)?;
-        let to = obj.get("to").or_else(|| obj.get("target")).and_then(Value::as_str)?;
+        let from = obj
+            .get("from")
+            .or_else(|| obj.get("source"))
+            .and_then(Value::as_str)?;
+        let to = obj
+            .get("to")
+            .or_else(|| obj.get("target"))
+            .and_then(Value::as_str)?;
         return Some((from.to_string(), to.to_string()));
     }
     if let Some(arr) = edge.as_array() {
@@ -142,13 +148,7 @@ pub fn diff_graph_snapshots(base: &GraphSnapshot, head: &GraphSnapshot) -> Seman
         let before = base.prompts.get(&node_id).cloned();
         let after = head.prompts.get(&node_id).cloned();
         if before != after {
-            prompt_changes.insert(
-                node_id,
-                PromptChange {
-                    before,
-                    after,
-                },
-            );
+            prompt_changes.insert(node_id, PromptChange { before, after });
         }
     }
 
@@ -248,12 +248,7 @@ fn format_exits(exits: &[String]) -> String {
 }
 
 fn format_prompt_diff(change: &PromptChange) -> String {
-    let before_lines: Vec<&str> = change
-        .before
-        .as_deref()
-        .unwrap_or("")
-        .lines()
-        .collect();
+    let before_lines: Vec<&str> = change.before.as_deref().unwrap_or("").lines().collect();
     let after_lines: Vec<&str> = change.after.as_deref().unwrap_or("").lines().collect();
 
     let mut out = String::new();
@@ -282,7 +277,10 @@ mod tests {
         GraphSnapshot {
             entry: Some("start".to_string()),
             exits: vec!["end".to_string()],
-            nodes: ["start", "plan", "end"].into_iter().map(str::to_string).collect(),
+            nodes: ["start", "plan", "end"]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
             edges: [("start", "plan"), ("plan", "end")]
                 .into_iter()
                 .map(|(a, b)| (a.to_string(), b.to_string()))
@@ -302,14 +300,10 @@ mod tests {
                 .into_iter()
                 .map(str::to_string)
                 .collect(),
-            edges: [
-                ("start", "plan"),
-                ("plan", "review"),
-                ("review", "end"),
-            ]
-            .into_iter()
-            .map(|(a, b)| (a.to_string(), b.to_string()))
-            .collect(),
+            edges: [("start", "plan"), ("plan", "review"), ("review", "end")]
+                .into_iter()
+                .map(|(a, b)| (a.to_string(), b.to_string()))
+                .collect(),
             prompts: BTreeMap::from([
                 (
                     "plan".to_string(),
@@ -337,8 +331,13 @@ mod tests {
         let snap = extract_graph_snapshot(&state);
         assert_eq!(snap.entry.as_deref(), Some("start"));
         assert!(snap.nodes.contains("plan"));
-        assert!(snap.edges.contains(&("start".to_string(), "plan".to_string())));
-        assert_eq!(snap.prompts.get("plan").map(String::as_str), Some("Do the thing."));
+        assert!(snap
+            .edges
+            .contains(&("start".to_string(), "plan".to_string())));
+        assert_eq!(
+            snap.prompts.get("plan").map(String::as_str),
+            Some("Do the thing.")
+        );
     }
 
     #[test]

--- a/crates/aivcs-core/src/diff/semantic_graph.rs
+++ b/crates/aivcs-core/src/diff/semantic_graph.rs
@@ -1,0 +1,364 @@
+//! Structural diff for oxidizedgraph-style snapshots embedded in commit state.
+//!
+//! TODO(stevedores-org/oxidizedgraph#60): swap this JSON structural diff for
+//! `oxidizedgraph::diff::Graph::diff` once upstream lands.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::Value;
+
+/// Serializable graph + prompt topology extracted from an aivcs state snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GraphSnapshot {
+    pub entry: Option<String>,
+    pub exits: Vec<String>,
+    pub nodes: BTreeSet<String>,
+    pub edges: BTreeSet<(String, String)>,
+    pub prompts: BTreeMap<String, String>,
+}
+
+impl GraphSnapshot {
+    pub fn has_semantic_content(&self) -> bool {
+        !self.nodes.is_empty()
+            || !self.edges.is_empty()
+            || !self.prompts.is_empty()
+            || self.entry.is_some()
+            || !self.exits.is_empty()
+    }
+}
+
+/// Delta between two graph snapshots.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SemanticGraphDiff {
+    pub prompt_changes: BTreeMap<String, PromptChange>,
+    pub nodes_added: Vec<String>,
+    pub nodes_removed: Vec<String>,
+    pub edges_added: Vec<(String, String)>,
+    pub edges_removed: Vec<(String, String)>,
+    pub entry_changed: Option<(Option<String>, Option<String>)>,
+    pub exits_changed: Option<(Vec<String>, Vec<String>)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptChange {
+    pub before: Option<String>,
+    pub after: Option<String>,
+}
+
+impl SemanticGraphDiff {
+    pub fn is_empty(&self) -> bool {
+        self.prompt_changes.is_empty()
+            && self.nodes_added.is_empty()
+            && self.nodes_removed.is_empty()
+            && self.edges_added.is_empty()
+            && self.edges_removed.is_empty()
+            && self.entry_changed.is_none()
+            && self.exits_changed.is_none()
+    }
+}
+
+/// Parse a graph snapshot from commit state JSON.
+///
+/// Supports:
+/// - top-level `graph` + `prompts` objects
+/// - node objects with inline `prompt` fields
+pub fn extract_graph_snapshot(state: &Value) -> GraphSnapshot {
+    let mut snapshot = GraphSnapshot::default();
+
+    if let Some(graph) = state.get("graph").and_then(Value::as_object) {
+        if let Some(entry) = graph.get("entry").and_then(Value::as_str) {
+            snapshot.entry = Some(entry.to_string());
+        }
+        if let Some(exits) = graph.get("exits").and_then(Value::as_array) {
+            snapshot.exits = exits
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect();
+        }
+        if let Some(nodes) = graph.get("nodes").and_then(Value::as_array) {
+            for node in nodes {
+                match node {
+                    Value::String(id) => {
+                        snapshot.nodes.insert(id.clone());
+                    }
+                    Value::Object(obj) => {
+                        if let Some(id) = obj.get("id").and_then(Value::as_str) {
+                            snapshot.nodes.insert(id.to_string());
+                            if let Some(prompt) = obj.get("prompt").and_then(Value::as_str) {
+                                snapshot.prompts.insert(id.to_string(), prompt.to_string());
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if let Some(edges) = graph.get("edges").and_then(Value::as_array) {
+            for edge in edges {
+                if let Some((from, to)) = parse_edge(edge) {
+                    snapshot.edges.insert((from, to));
+                }
+            }
+        }
+    }
+
+    if let Some(prompts) = state.get("prompts").and_then(Value::as_object) {
+        for (node_id, prompt) in prompts {
+            if let Some(text) = prompt.as_str() {
+                snapshot.prompts.insert(node_id.clone(), text.to_string());
+            }
+        }
+    }
+
+    snapshot
+}
+
+fn parse_edge(edge: &Value) -> Option<(String, String)> {
+    if let Some(obj) = edge.as_object() {
+        let from = obj.get("from").or_else(|| obj.get("source")).and_then(Value::as_str)?;
+        let to = obj.get("to").or_else(|| obj.get("target")).and_then(Value::as_str)?;
+        return Some((from.to_string(), to.to_string()));
+    }
+    if let Some(arr) = edge.as_array() {
+        if arr.len() == 2 {
+            let from = arr[0].as_str()?;
+            let to = arr[1].as_str()?;
+            return Some((from.to_string(), to.to_string()));
+        }
+    }
+    None
+}
+
+pub fn diff_graph_snapshots(base: &GraphSnapshot, head: &GraphSnapshot) -> SemanticGraphDiff {
+    let mut prompt_changes = BTreeMap::new();
+    let node_ids: BTreeSet<_> = base
+        .prompts
+        .keys()
+        .chain(head.prompts.keys())
+        .cloned()
+        .collect();
+    for node_id in node_ids {
+        let before = base.prompts.get(&node_id).cloned();
+        let after = head.prompts.get(&node_id).cloned();
+        if before != after {
+            prompt_changes.insert(
+                node_id,
+                PromptChange {
+                    before,
+                    after,
+                },
+            );
+        }
+    }
+
+    let nodes_added: Vec<_> = head.nodes.difference(&base.nodes).cloned().collect();
+    let nodes_removed: Vec<_> = base.nodes.difference(&head.nodes).cloned().collect();
+    let edges_added: Vec<_> = head.edges.difference(&base.edges).cloned().collect();
+    let edges_removed: Vec<_> = base.edges.difference(&head.edges).cloned().collect();
+
+    let entry_changed = if base.entry != head.entry {
+        Some((base.entry.clone(), head.entry.clone()))
+    } else {
+        None
+    };
+    let exits_changed = if base.exits != head.exits {
+        Some((base.exits.clone(), head.exits.clone()))
+    } else {
+        None
+    };
+
+    SemanticGraphDiff {
+        prompt_changes,
+        nodes_added,
+        nodes_removed,
+        edges_added,
+        edges_removed,
+        entry_changed,
+        exits_changed,
+    }
+}
+
+pub fn format_semantic_diff_markdown(diff: &SemanticGraphDiff) -> String {
+    if diff.is_empty() {
+        return "_No semantic delta — only code/infra changes._".to_string();
+    }
+
+    let mut out = String::new();
+
+    if !diff.prompt_changes.is_empty() {
+        out.push_str("### Prompt changes\n\n");
+        for (node_id, change) in &diff.prompt_changes {
+            out.push_str(&format!("**{node_id}**\n\n"));
+            out.push_str("```diff\n");
+            out.push_str(&format_prompt_diff(change));
+            out.push_str("```\n\n");
+        }
+    }
+
+    if !diff.nodes_added.is_empty()
+        || !diff.nodes_removed.is_empty()
+        || !diff.edges_added.is_empty()
+        || !diff.edges_removed.is_empty()
+    {
+        out.push_str("### Graph topology\n\n");
+        for node in &diff.nodes_added {
+            out.push_str(&format!("- Added node `{node}`\n"));
+        }
+        for node in &diff.nodes_removed {
+            out.push_str(&format!("- Removed node `{node}`\n"));
+        }
+        for (from, to) in &diff.edges_added {
+            out.push_str(&format!("- Added edge `{from}` → `{to}`\n"));
+        }
+        for (from, to) in &diff.edges_removed {
+            out.push_str(&format!("- Removed edge `{from}` → `{to}`\n"));
+        }
+        out.push('\n');
+    }
+
+    if let Some((before, after)) = &diff.entry_changed {
+        out.push_str("### Entry / exits\n\n");
+        out.push_str(&format!(
+            "- Entry: `{}` → `{}`\n",
+            before.as_deref().unwrap_or("(none)"),
+            after.as_deref().unwrap_or("(none)")
+        ));
+    }
+    if let Some((before, after)) = &diff.exits_changed {
+        if diff.entry_changed.is_none() {
+            out.push_str("### Entry / exits\n\n");
+        }
+        out.push_str(&format!(
+            "- Exits: `{}` → `{}`\n",
+            format_exits(before),
+            format_exits(after)
+        ));
+    }
+
+    out.trim_end().to_string()
+}
+
+fn format_exits(exits: &[String]) -> String {
+    if exits.is_empty() {
+        "(none)".to_string()
+    } else {
+        exits.join(", ")
+    }
+}
+
+fn format_prompt_diff(change: &PromptChange) -> String {
+    let before_lines: Vec<&str> = change
+        .before
+        .as_deref()
+        .unwrap_or("")
+        .lines()
+        .collect();
+    let after_lines: Vec<&str> = change.after.as_deref().unwrap_or("").lines().collect();
+
+    let mut out = String::new();
+    for line in &before_lines {
+        out.push('-');
+        out.push_str(line);
+        out.push('\n');
+    }
+    for line in &after_lines {
+        out.push('+');
+        out.push_str(line);
+        out.push('\n');
+    }
+    if before_lines.is_empty() && after_lines.is_empty() {
+        out.push_str("(empty prompt)\n");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_base() -> GraphSnapshot {
+        GraphSnapshot {
+            entry: Some("start".to_string()),
+            exits: vec!["end".to_string()],
+            nodes: ["start", "plan", "end"].into_iter().map(str::to_string).collect(),
+            edges: [("start", "plan"), ("plan", "end")]
+                .into_iter()
+                .map(|(a, b)| (a.to_string(), b.to_string()))
+                .collect(),
+            prompts: BTreeMap::from([
+                ("plan".to_string(), "Plan carefully.\nStep 1.".to_string()),
+                ("end".to_string(), "Finish.".to_string()),
+            ]),
+        }
+    }
+
+    fn sample_head() -> GraphSnapshot {
+        GraphSnapshot {
+            entry: Some("start".to_string()),
+            exits: vec!["end".to_string()],
+            nodes: ["start", "plan", "review", "end"]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            edges: [
+                ("start", "plan"),
+                ("plan", "review"),
+                ("review", "end"),
+            ]
+            .into_iter()
+            .map(|(a, b)| (a.to_string(), b.to_string()))
+            .collect(),
+            prompts: BTreeMap::from([
+                (
+                    "plan".to_string(),
+                    "Plan carefully.\nStep 1.\nStep 2.".to_string(),
+                ),
+                ("review".to_string(), "Review output.".to_string()),
+                ("end".to_string(), "Finish.".to_string()),
+            ]),
+        }
+    }
+
+    #[test]
+    fn extract_graph_snapshot_from_state_json() {
+        let state = json!({
+            "graph": {
+                "entry": "start",
+                "exits": ["end"],
+                "nodes": ["start", "plan"],
+                "edges": [{"from": "start", "to": "plan"}]
+            },
+            "prompts": {
+                "plan": "Do the thing."
+            }
+        });
+        let snap = extract_graph_snapshot(&state);
+        assert_eq!(snap.entry.as_deref(), Some("start"));
+        assert!(snap.nodes.contains("plan"));
+        assert!(snap.edges.contains(&("start".to_string(), "plan".to_string())));
+        assert_eq!(snap.prompts.get("plan").map(String::as_str), Some("Do the thing."));
+    }
+
+    #[test]
+    fn diff_and_markdown_snapshot_matches_fixture() {
+        let diff = diff_graph_snapshots(&sample_base(), &sample_head());
+        let md = format_semantic_diff_markdown(&diff);
+
+        assert!(md.contains("### Prompt changes"));
+        assert!(md.contains("**plan**"));
+        assert!(md.contains("+Step 2."));
+        assert!(md.contains("### Graph topology"));
+        assert!(md.contains("Added node `review`"));
+        assert!(md.contains("Added edge `plan` → `review`"));
+        assert!(md.contains("Removed edge `plan` → `end`"));
+    }
+
+    #[test]
+    fn empty_diff_emits_no_delta_message() {
+        let snap = sample_base();
+        let md = format_semantic_diff_markdown(&diff_graph_snapshots(&snap, &snap));
+        assert_eq!(md, "_No semantic delta — only code/infra changes._");
+    }
+}

--- a/crates/aivcs-core/src/git.rs
+++ b/crates/aivcs-core/src/git.rs
@@ -290,18 +290,12 @@ mod tests {
         assert_eq!(parse_github_remote("git@github.com:/repo"), None);
         assert_eq!(parse_github_remote("git@github.com:owner/"), None);
         // HTTPS-form space rejection — develop covers SCP-SSH spaces but not HTTPS.
-        assert_eq!(
-            parse_github_remote("https://github.com/foo bar/baz"),
-            None
-        );
+        assert_eq!(parse_github_remote("https://github.com/foo bar/baz"), None);
         // HTTPS-form empty segment — SCP-style empty covered above; HTTPS variant not yet.
         assert_eq!(parse_github_remote("https://github.com//repo"), None);
         assert_eq!(parse_github_remote("https://github.com/owner/"), None);
         // Backtick / command-substitution syntax — must not parse as a valid owner.
-        assert_eq!(
-            parse_github_remote("git@github.com:`whoami`/repo"),
-            None
-        );
+        assert_eq!(parse_github_remote("git@github.com:`whoami`/repo"), None);
     }
 
     #[test]

--- a/crates/aivcs-core/src/git.rs
+++ b/crates/aivcs-core/src/git.rs
@@ -289,6 +289,19 @@ mod tests {
         // Empty segments still rejected (regression guard).
         assert_eq!(parse_github_remote("git@github.com:/repo"), None);
         assert_eq!(parse_github_remote("git@github.com:owner/"), None);
+        // HTTPS-form space rejection — develop covers SCP-SSH spaces but not HTTPS.
+        assert_eq!(
+            parse_github_remote("https://github.com/foo bar/baz"),
+            None
+        );
+        // HTTPS-form empty segment — SCP-style empty covered above; HTTPS variant not yet.
+        assert_eq!(parse_github_remote("https://github.com//repo"), None);
+        assert_eq!(parse_github_remote("https://github.com/owner/"), None);
+        // Backtick / command-substitution syntax — must not parse as a valid owner.
+        assert_eq!(
+            parse_github_remote("git@github.com:`whoami`/repo"),
+            None
+        );
     }
 
     #[test]

--- a/crates/aivcs-core/src/lib.rs
+++ b/crates/aivcs-core/src/lib.rs
@@ -85,13 +85,13 @@ pub use diff::lcs_diff::{
     diff_tool_calls as diff_tool_calls_lcs, DiffSummary, ParamChange,
     ToolCallChange as LcsToolCallChange, ToolCallEntry,
 };
-pub use diff::state_diff::{
-    diff_run_states, diff_scoped_state, extract_last_checkpoint, ScopedStateDiff, StateDelta,
-    CHECKPOINT_SAVED_KIND,
-};
 pub use diff::semantic_graph::{
     diff_graph_snapshots, extract_graph_snapshot, format_semantic_diff_markdown, GraphSnapshot,
     SemanticGraphDiff,
+};
+pub use diff::state_diff::{
+    diff_run_states, diff_scoped_state, extract_last_checkpoint, ScopedStateDiff, StateDelta,
+    CHECKPOINT_SAVED_KIND,
 };
 pub use orchestration::{
     default_role_templates, deterministic_role_order, merge_role_outputs, validate_handoff,

--- a/crates/aivcs-core/src/lib.rs
+++ b/crates/aivcs-core/src/lib.rs
@@ -89,6 +89,10 @@ pub use diff::state_diff::{
     diff_run_states, diff_scoped_state, extract_last_checkpoint, ScopedStateDiff, StateDelta,
     CHECKPOINT_SAVED_KIND,
 };
+pub use diff::semantic_graph::{
+    diff_graph_snapshots, extract_graph_snapshot, format_semantic_diff_markdown, GraphSnapshot,
+    SemanticGraphDiff,
+};
 pub use orchestration::{
     default_role_templates, deterministic_role_order, merge_role_outputs, validate_handoff,
     validate_parallel_roles, AgentRole, HandoffValidationError, MergeConflict,


### PR DESCRIPTION
## Summary

- Adds `aivcs pr-semantic-summary [--branch <name>] [--base main]` (closes #247)
- New `aivcs-core` module `diff::semantic_graph` extracts graph/prompt snapshots from commit state JSON and emits Markdown structural deltas (prompt ```diff blocks, topology bullets, entry/exit notes)
- Reuses `pr-note` linkage output, then appends semantic diff section for PR bodies (SDF dual-ledger Phase 2.1 / #220)
- Adds 4 regression asserts from #243 to `parse_github_remote_rejects_malformed_segments`
- TODO in source: swap for `oxidizedgraph::diff::Graph::diff` when stevedores-org/oxidizedgraph#60 lands

## Test plan

- [x] `cargo test -p aivcs-core semantic_graph`
- [x] `cargo test -p aivcs-core parse_github_remote_rejects_malformed`
- [x] `cargo test -p aivcs-cli test_pr_semantic_summary`
- [x] rustfmt applied (fmt shard)
- [ ] CI green on PR

<!-- aivcs-linkage -->
aivcs-commit: code-only-cli-change-no-cognitive-snapshot

Closes #247
Closes #243