### PR TITLE
feat(gateway): link aivcs mcp memory backend to data-fabric-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "data-fabric-client",
  "hex",
  "jsonwebtoken",
  "serde",
@@ -1228,6 +1229,19 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "data-fabric-client"
+version = "0.1.1"
+source = "git+https://github.com/stevedores-org/data-fabric.git?rev=36a9e60#36a9e6013dc52b6759f87dbd5928d7e54288b056"
+dependencies = [
+ "percent-encoding",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+]
 
 [[package]]
 name = "deranged"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,8 @@ tempfile = "3.10"
 
 # External crates (Stevedores ecosystem)
 oxidizedgraph = "0.2.0"
+data-fabric-client = { git = "https://github.com/stevedores-org/data-fabric.git", rev = "36a9e60", package = "data-fabric-client" }
+
 
 # Internal crates (use published versions for crates.io)
 aivcs-core = { version = "0.3.2", path = "crates/aivcs-core" }

--- a/crates/aivcs-mcp-gateway/Cargo.toml
+++ b/crates/aivcs-mcp-gateway/Cargo.toml
@@ -19,3 +19,5 @@ aivcs-core = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 tower = { version = "0.4", features = ["util"] }
+data-fabric-client = { workspace = true }
+


### PR DESCRIPTION
Closes #278. This pull request adds the workspace dependency data-fabric-client and adds it to aivcs-mcp-gateway to prepare for backing the unified memory::* tool family with the Stevedores Data Fabric (GLCDF).

aivcs-commit: code-only-link-data-fabric-client-no-cognitive-snapshot