### PR TITLE
fix(cli): resolve clap short option conflicts for pr open command

### DIFF
--- a/crates/aivcs-cli/src/main.rs
+++ b/crates/aivcs-cli/src/main.rs
@@ -268,11 +268,11 @@ enum PrAction {
         body: String,
 
         /// Head branch (source of changes)
-        #[arg(short, long)]
+        #[arg(long)]
         head: String,
 
         /// Base branch (target for changes, default: main)
-        #[arg(short, long, default_value = "main")]
+        #[arg(long, default_value = "main")]
         base: String,
 
         /// GitHub organization/owner


### PR DESCRIPTION
Resolves the clap short option conflicts where both body and base mapped to -b, and head mapped to -h conflicting with help.